### PR TITLE
Reuse cookies and allow to specify options

### DIFF
--- a/claimer.js
+++ b/claimer.js
@@ -6,6 +6,7 @@ const Config = require(`${__dirname}/config.json`);
 const Logger = require("tracer").console(`${__dirname}/logger.js`);
 const Package = require("./package.json");
 const TwoFactor = require("node-2fa");
+const Cookie = require('tough-cookie').Cookie;
 
 function isUpToDate() {
     return new Promise((res, rej) => {
@@ -42,12 +43,33 @@ async function freeGamesPromotions(client, country = "US", allowCountries = "US"
     }));
 }
 
+function getChromeCookie(cookie) {
+    cookie = Object.assign({}, cookie);
+    cookie.name = cookie.key;
+    if (cookie.expires instanceof Date) {
+        cookie.expires = cookie.expires.getTime() / 1000.0;
+    } else {
+        delete cookie.expires;
+    }
+    return cookie;
+}
+
+function getToughCookie(cookie) {
+    cookie = Object.assign({}, cookie);
+    cookie.key = cookie.name;
+    cookie.expires = new Date(cookie.expires * 1000);
+    return new Cookie(cookie);
+}
+
 (async() => {
     if (!await isUpToDate()) {
         Logger.warn(`There is a new version available: ${Package.url}`);
     }
 
-    let { accounts, delay, loop } = Config;
+    let { accounts, options, delay, loop } = Config;
+    if (!options) {
+        options = {};
+    }
     let sleep = delay => new Promise(res => setTimeout(res, delay * 60000));
     do {
         if (process.argv.length > 2) {
@@ -67,7 +89,10 @@ async function freeGamesPromotions(client, country = "US", allowCountries = "US"
                 account.twoFactorCode = token;
             }
 
-            let client = new EpicGames(account);
+            let epicOptions = Object.assign({}, options);
+            Object.assign(epicOptions, account);
+
+            let client = new EpicGames(epicOptions);
 
             if (!await client.init()) {
                 throw new Error("Error while initialize process.");
@@ -76,8 +101,32 @@ async function freeGamesPromotions(client, country = "US", allowCountries = "US"
             if (!await client.login(account).catch(() => false)) {
                 Logger.warn(`Failed to login as ${client.config.email}, please attempt manually.`);
 
-                let auth = await ClientLoginAdapter.init(account);
+
+                if (account.rememberLastSession) {
+                    if (!options.cookies) {
+                        options.cookies = [];
+                    }
+                    if (account.cookies && account.cookies.length) {
+                        options.cookies = options.cookies.concat(account.cookies);
+                    }
+                    client.http.jar._jar.store.getAllCookies((err, cookies) => {
+                        for (const cookie of cookies) {
+                            options.cookies.push(getChromeCookie(cookie));
+                        }
+                    });
+                }
+
+                let auth = await ClientLoginAdapter.init(account, options);
                 let exchangeCode = await auth.getExchangeCode();
+
+                if (account.rememberLastSession) {
+                    let cookies = await auth.getPage().then(p => p.cookies());
+                    for (let cookie of cookies) {
+                        cookie = getToughCookie(cookie);
+                        client.http.jar.setCookie(cookie, "https://" + cookie.domain);
+                    }
+                }
+
                 await auth.close();
 
                 if (!await client.login(null, exchangeCode)) {

--- a/config.json
+++ b/config.json
@@ -10,9 +10,11 @@
 			"email": "YOUR_EMAIL2_HERE",
 			"password": "YOUR_PASSWORD2_HERE",
 			"secret": "YOUR_2FA_SECRET2_HERE_OR_EMPTY",
-			"rememberLastSession": true
+			"rememberLastSession": true,
+			"cookies": []
 		}
 	],
+	"options": {},
 	"delay": 1440,
 	"loop": true
 }


### PR DESCRIPTION
Currently when login fails then `epicgames-client-login-adapter` is used to login with browser which uses completely separate cookies. Because of this even after manually logging in it won't work next time and we'll get asked to solve CAPTCHA every time.
This PR fixes that by reusing cookies.
Also allow to pass extra configuration options as well as cookies.

Note that this is still WIP. need to fix few things.
Also this depends on SzymonLisowiec/node-epicgames-client-login-adapter/pull/4 so can't be used before that is released.
When this will be done then #42 #29  should be fixed.
