### PR TITLE
Improve error handling

### DIFF
--- a/claimer.js
+++ b/claimer.js
@@ -73,7 +73,14 @@ async function freeGamesPromotions(client, country = "US", allowCountries = "US"
                 throw new Error("Error while initialize process.");
             }
 
-            if (!await client.login(account).catch(() => false)) {
+            let success = false;
+            try {
+                success = await client.login(account);
+            } catch (error) {
+                Logger.warn(error.message);
+            }
+
+            if (!success) {
                 Logger.warn(`Failed to login as ${client.config.email}, please attempt manually.`);
 
                 let auth = await ClientLoginAdapter.init(account);


### PR DESCRIPTION
Currently you wouldn't get any info about why login failed because all exceptions were swallowed.
This PR fixes that so you'll get output like

```
2020-08-30 | 04:06:04.480 | WARN  | Invalid captcha!
2020-08-30 | 04:06:04.483 | WARN  | Failed to login as xxx@xxx.com, please attempt manually.
```
