### PR TITLE
Fix promos filter

### DIFF
--- a/claimer.js
+++ b/claimer.js
@@ -8,6 +8,8 @@ const Package = require("./package.json");
 const TwoFactor = require("node-2fa");
 const Cookie = require('tough-cookie').Cookie;
 
+const { freeGamesPromotions } = require('./src/gamePromotions');
+
 function isUpToDate() {
     return new Promise((res, rej) => {
         CheckUpdate({
@@ -23,24 +25,6 @@ function isUpToDate() {
             }
         });
     });
-}
-
-async function freeGamesPromotions(client, country = "US", allowCountries = "US", locale = "en-US") {
-    let { data } = await client.freeGamesPromotions(country, allowCountries, locale);
-    let { elements } = data.Catalog.searchStore;
-    let free = elements.filter(offer => offer.promotions
-        && offer.promotions.promotionalOffers.length > 0
-        && offer.promotions.promotionalOffers[0].promotionalOffers.find(p => p.discountSetting.discountPercentage === 0));
-    let isBundle = promo => Boolean(promo.categories.find(cat => cat.path === "bundles"));
-    let getOffer = promo => (isBundle(promo)
-        ? client.getBundleForSlug(promo.productSlug, locale)
-        : client.getProductForSlug(promo.productSlug, locale));
-    let freeOffers = await Promise.all(free.map(promo => getOffer(promo)));
-    return freeOffers.filter(offer => !offer.error).map(offer => ({
-        "title":     offer.productName || offer._title,
-        "id":        (offer.pages ? offer.pages[0] : offer).offer.id,
-        "namespace": (offer.pages ? offer.pages[0] : offer).offer.namespace
-    }));
 }
 
 function getChromeCookie(cookie) {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     ],
     "main": "claimer.js",
     "scripts": {
-        "test": "echo \"Error: no test specified\" && exit 1",
+        "test": "mocha",
         "start": "node claimer.js"
     },
     "license": "MIT",
@@ -28,7 +28,9 @@
     "homepage": "https://github.com/revadike/epicgames-freebies-claimer",
     "url": "https://github.com/revadike/epicgames-freebies-claimer",
     "devDependencies": {
-        "eslint": "^6.8.0"
+        "chai": "*",
+        "eslint": "^6.8.0",
+        "mocha": "*"
     },
     "dependencies": {
         "check-update-github": "^0.0.4",

--- a/src/gamePromotions.js
+++ b/src/gamePromotions.js
@@ -1,0 +1,35 @@
+
+async function freeGamesPromotions(client, country = "US", allowCountries = "US", locale = "en-US") {
+    let { data } = await client.freeGamesPromotions(country, allowCountries, locale);
+    let { elements } = data.Catalog.searchStore;
+    let free = elements.filter(offer => offer.promotions
+    && offer.promotions.promotionalOffers.length > 0
+    && offer.promotions.promotionalOffers[0].promotionalOffers.find(p => p.discountSetting.discountPercentage === 0));
+    let isBundle = promo => Boolean(promo.categories.find(cat => cat.path === "bundles"));
+    let getOffer = promo => (isBundle(promo)
+    ? client.getBundleForSlug(promo.productSlug.split('/')[0], locale)
+    : client.getProductForSlug(promo.productSlug.split('/')[0], locale));
+
+    let freeOffers = await Promise.all(free.map(async promo => {
+        let o = await getOffer(promo);
+        let page;
+        if (o.pages) {
+            page = o.pages.find(p => p._urlPattern.includes(promo.productSlug));
+        } else {
+            page = o;
+        }
+        if (!page) {
+            [page] = o.pages;
+        }
+
+        return {
+            "title":     o.productName || o._title,
+            "id":        page.offer.id,
+            "namespace": page.offer.namespace
+        }
+    }));
+
+    return freeOffers;
+}
+
+module.exports = { freeGamesPromotions };

--- a/test/data/bundles_shadowrun-collection_2020-09-01.json
+++ b/test/data/bundles_shadowrun-collection_2020-09-01.json
@@ -1,0 +1,416 @@
+{
+  "offer": {
+    "regionRestrictions": {
+      "_type": "Store Region Filtering"
+    },
+    "_type": "Diesel Offer",
+    "namespace": "bd8a7e894699493fb21503837f7b66c5",
+    "id": "c5cb60ecc6554c6a8d9a682b87ab04bb",
+    "hasOffer": true
+  },
+  "jcr:isCheckedOut": true,
+  "data": {
+    "productLinks": {
+      "_type": "Diesel Product Lins"
+    },
+    "socialLinks": {
+      "_type": "Diesel Social Links",
+      "title": "Follow Shadowrun ",
+      "linkHomepage": "https://www.paradoxplaza.com/shadowrun-all/"
+    },
+    "requirements": {
+      "languages": [
+        "Audio: English",
+        "Text: English"
+      ],
+      "systems": [
+        {
+          "_type": "Diesel System Detail",
+          "systemType": "Windows",
+          "details": [
+            {
+              "_type": "Diesel System Detail Item",
+              "title": "OS",
+              "minimum": "Windows XP SP3/Vista/Windows 7 & 8",
+              "recommended": "Windows XP SP3/Vista/Windows 7 & 8"
+            },
+            {
+              "_type": "Diesel System Detail Item",
+              "title": "Processor",
+              "minimum": "x86-compatible 1.8GHz or faster processor",
+              "recommended": "x86-compatible 2GHz or faster processor"
+            },
+            {
+              "_type": "Diesel System Detail Item",
+              "title": "Memory",
+              "minimum": "2 GB RAM",
+              "recommended": "4 GB RAM"
+            },
+            {
+              "_type": "Diesel System Detail Item",
+              "title": "Storage",
+              "minimum": "30 GB available space",
+              "recommended": "30 GB available space"
+            },
+            {
+              "_type": "Diesel System Detail Item",
+              "title": "Direct X",
+              "minimum": "Version 9.0",
+              "recommended": "Version 9.0"
+            },
+            {
+              "_type": "Diesel System Detail Item",
+              "title": "Graphics",
+              "minimum": "DirectX compatible 3D graphics card with at least 256MB of addressable memory",
+              "recommended": " DirectX compatible 3D graphics card with 512MB of addressable memory"
+            }
+          ]
+        }
+      ],
+      "accountRequirements": "NO_REQUIREMENTS",
+      "_type": "Diesel System Details",
+      "rating": {
+        "_type": "Diesel Rating"
+      }
+    },
+    "footer": {
+      "_type": "Diesel Product Footer",
+      "privacyPolicyLink": {
+        "_type": "Diesel Link"
+      }
+    },
+    "meta": {
+      "releaseDate": "2020-08-20T13:00:00.000Z",
+      "_type": "Epic Store Meta",
+      "publisher": [
+        "Paradox Interactive"
+      ],
+      "logo": {
+        "src": "https://cdn2.unrealengine.com/logo-400x400-400x400-777098045.png",
+        "_type": "Epic Store Image"
+      },
+      "developer": [
+        "Harebrained Schemes"
+      ],
+      "platform": [
+        "Windows"
+      ]
+    },
+    "_type": "Store Bundle Detail",
+    "about": {
+      "image": {
+        "src": "https://cdn2.unrealengine.com/landscape-image-shadowcoll-2560x1440-777100077.jpg",
+        "_type": "Diesel Image"
+      },
+      "developerAttribution": "Harebrained Schemes",
+      "_type": "Diesel Product About",
+      "publisherAttribution": " Paradox Interactive",
+      "description": "# Shadowrun Returns\n\nThe unique cyberpunk-meets-fantasy world of Shadowrun has gained a huge cult following since its creation nearly 25 years ago. Creator Jordan Weisman returns to the world of Shadowrun, modernizing this classic game setting as a single player, turn-based tactical RPG. In the urban sprawl of the Seattle metroplex, the search for a mysterious killer sets you on a trail that leads from the darkest slums to the city’s most powerful megacorps.\n\nYou will need to tread carefully, enlist the aid of other runners, and master powerful forces of technology and magic in order to emerge from the shadows of Seattle unscathed.\n\n# Shadowrun Dragonfall - Director Cut\n\nShadowrun: Dragonfall - Director’s Cut is a standalone release of Harebrained Schemes' critically-acclaimed Dragonfall campaign, which first premiered as a major expansion for Shadowrun Returns. The Director's Cut adds a host of new content and enhancements to the original game: 5 all-new missions, alternate endings, new music, a redesigned interface, team customization options, a revamped combat system, and more - making it the definitive version of this one-of-a-kind cyberpunk RPG experience.\n\n# Shadowrun Hong Kong - Extended Edition\n\nShadowrun: Hong Kong - Extended Edition is the capstone title in Harebrained Schemes' Shadowrun series - and includes the all-new, 6+ hr Shadows of Hong Kong Bonus Campaign. Experience the most impressive Shadowrun RPG yet, hailed as one of the best cRPG / strategy games of 2015!",
+      "shortDescription": "Shadowrun Collection includes Shadowrun Returns (Base Game), Shadowrun Dragonfall - Director Cut (Base Game) and Shadowrun Hong Kong - Extended Edition (Base Game)",
+      "title": "Shadowrun Collection",
+      "developerLogo": {
+        "_type": "Diesel Image"
+      }
+    },
+    "banner": {
+      "showPromotion": false,
+      "_type": "Epic Store Product Banner",
+      "link": {
+        "_type": "Diesel Link"
+      }
+    },
+    "includes": {
+      "_type": "Store Bundle Includes",
+      "items": [
+        {
+          "image": {
+            "src": "https://cdn2.unrealengine.com/egs-shadowrunreturns-harebrainedschemes-s1-2560x1440-768642852.jpg",
+            "_type": "Epic Store Image"
+          },
+          "_type": "Store Bundle Included Section",
+          "link": {
+            "src": "/product/shadowrun-returns",
+            "_type": "Diesel Link",
+            "title": "Shadowrun Returns"
+          },
+          "description": "The unique cyberpunk-meets-fantasy world of Shadowrun has gained a huge cult following since its creation. Creator Jordan Weisman returns to the world of Shadowrun, modernizing this classic game setting as a single player, turn-based tactical RPG.",
+          "title": "Shadowrun Returns"
+        },
+        {
+          "image": {
+            "src": "https://cdn2.unrealengine.com/egs-shadowrundragonfalldirectorcut-harebrainedschemes-s1-2560x1440-769294674.jpg",
+            "_type": "Epic Store Image"
+          },
+          "_type": "Store Bundle Included Section",
+          "link": {
+            "src": "/product/shadowrun-dragonfall",
+            "_type": "Diesel Link",
+            "title": "Shadowrun: Dragonfall"
+          },
+          "description": "Harebrained Schemes' biggest Shadowrun game to date, and the definitive Shadowrun RPG experience available on PC. A standalone title with tons of new content & improvements!",
+          "title": "Shadowrun: Dragonfall - Director’s Cut"
+        },
+        {
+          "image": {
+            "src": "https://cdn2.unrealengine.com/egs-shadowrunhongkongextendededition-harebrainedschemes-s1-2560x1440-768923401.jpg",
+            "_type": "Epic Store Image"
+          },
+          "_type": "Store Bundle Included Section",
+          "link": {
+            "src": "/product/shadowrun-hong-kong",
+            "_type": "Diesel Link",
+            "title": "Shadowrun Hong Kong - Extended Edition"
+          },
+          "description": "Shadowrun: Hong Kong - Extended Edition is the capstone title in Harebrained Schemes' Shadowrun series - and includes the all-new, 6+ hr Shadows of Hong Kong Bonus Campaign.",
+          "title": "Shadowrun Hong Kong - Extended Edition"
+        }
+      ]
+    },
+    "carousel": {
+      "_type": "Diesel Carousel",
+      "items": [
+        {
+          "image": {
+            "src": "https://cdn2.unrealengine.com/landscape-image-shadowcoll-2560x1440-777100077.jpg",
+            "_type": "Diesel Image"
+          },
+          "_type": "Diesel Carousel Item - Image OR Video",
+          "video": {
+            "loop": false,
+            "_type": "Diesel Video",
+            "hasFullScreen": false,
+            "hasControls": false,
+            "muted": false,
+            "autoplay": false
+          }
+        },
+        {
+          "image": {
+            "src": "https://cdn2.unrealengine.com/egs-shadowruncollection-harebrainedschemes-g1a-01-1920x1080-785870290.jpg",
+            "_type": "Diesel Image"
+          },
+          "_type": "Diesel Carousel Item - Image OR Video",
+          "video": {
+            "loop": false,
+            "_type": "Diesel Video",
+            "hasFullScreen": false,
+            "hasControls": false,
+            "muted": false,
+            "autoplay": false
+          }
+        },
+        {
+          "image": {
+            "src": "https://cdn2.unrealengine.com/egs-shadowruncollection-harebrainedschemes-g1a-02-1920x1080-785870323.jpg",
+            "_type": "Diesel Image"
+          },
+          "_type": "Diesel Carousel Item - Image OR Video",
+          "video": {
+            "loop": false,
+            "_type": "Diesel Video",
+            "hasFullScreen": false,
+            "hasControls": false,
+            "muted": false,
+            "autoplay": false
+          }
+        },
+        {
+          "image": {
+            "src": "https://cdn2.unrealengine.com/egs-shadowruncollection-harebrainedschemes-g1a-03-1920x1080-785870474.jpg",
+            "_type": "Diesel Image"
+          },
+          "_type": "Diesel Carousel Item - Image OR Video",
+          "video": {
+            "loop": false,
+            "_type": "Diesel Video",
+            "hasFullScreen": false,
+            "hasControls": false,
+            "muted": false,
+            "autoplay": false
+          }
+        },
+        {
+          "image": {
+            "src": "https://cdn2.unrealengine.com/egs-shadowruncollection-harebrainedschemes-g1a-04-1920x1080-785870331.jpg",
+            "_type": "Diesel Image"
+          },
+          "_type": "Diesel Carousel Item - Image OR Video",
+          "video": {
+            "loop": false,
+            "_type": "Diesel Video",
+            "hasFullScreen": false,
+            "hasControls": false,
+            "muted": false,
+            "autoplay": false
+          }
+        },
+        {
+          "image": {
+            "src": "https://cdn2.unrealengine.com/egs-shadowruncollection-harebrainedschemes-g1a-05-1920x1080-785870547.jpg",
+            "_type": "Diesel Image"
+          },
+          "_type": "Diesel Carousel Item - Image OR Video",
+          "video": {
+            "loop": false,
+            "_type": "Diesel Video",
+            "hasFullScreen": false,
+            "hasControls": false,
+            "muted": false,
+            "autoplay": false
+          }
+        },
+        {
+          "image": {
+            "src": "https://cdn2.unrealengine.com/egs-shadowruncollection-harebrainedschemes-g1a-06-1920x1080-785870233.jpg",
+            "_type": "Diesel Image"
+          },
+          "_type": "Diesel Carousel Item - Image OR Video",
+          "video": {
+            "loop": false,
+            "_type": "Diesel Video",
+            "hasFullScreen": false,
+            "hasControls": false,
+            "muted": false,
+            "autoplay": false
+          }
+        },
+        {
+          "image": {
+            "src": "https://cdn2.unrealengine.com/egs-shadowruncollection-harebrainedschemes-g1a-07-1920x1080-785870678.jpg",
+            "_type": "Diesel Image"
+          },
+          "_type": "Diesel Carousel Item - Image OR Video",
+          "video": {
+            "loop": false,
+            "_type": "Diesel Video",
+            "hasFullScreen": false,
+            "hasControls": false,
+            "muted": false,
+            "autoplay": false
+          }
+        },
+        {
+          "image": {
+            "src": "https://cdn2.unrealengine.com/egs-shadowruncollection-harebrainedschemes-g1a-08-1920x1080-785870757.jpg",
+            "_type": "Diesel Image"
+          },
+          "_type": "Diesel Carousel Item - Image OR Video",
+          "video": {
+            "loop": false,
+            "_type": "Diesel Video",
+            "hasFullScreen": false,
+            "hasControls": false,
+            "muted": false,
+            "autoplay": false
+          }
+        },
+        {
+          "image": {
+            "src": "https://cdn2.unrealengine.com/egs-shadowruncollection-harebrainedschemes-g1a-09-1920x1080-785870879.jpg",
+            "_type": "Diesel Image"
+          },
+          "_type": "Diesel Carousel Item - Image OR Video",
+          "video": {
+            "loop": false,
+            "_type": "Diesel Video",
+            "hasFullScreen": false,
+            "hasControls": false,
+            "muted": false,
+            "autoplay": false
+          }
+        },
+        {
+          "image": {
+            "src": "https://cdn2.unrealengine.com/egs-shadowruncollection-harebrainedschemes-g1a-10-1920x1080-785870817.jpg",
+            "_type": "Diesel Image"
+          },
+          "_type": "Diesel Carousel Item - Image OR Video",
+          "video": {
+            "loop": false,
+            "_type": "Diesel Video",
+            "hasFullScreen": false,
+            "hasControls": false,
+            "muted": false,
+            "autoplay": false
+          }
+        },
+        {
+          "image": {
+            "src": "https://cdn2.unrealengine.com/egs-shadowruncollection-harebrainedschemes-g1a-11-1920x1080-785871134.jpg",
+            "_type": "Diesel Image"
+          },
+          "_type": "Diesel Carousel Item - Image OR Video",
+          "video": {
+            "loop": false,
+            "_type": "Diesel Video",
+            "hasFullScreen": false,
+            "hasControls": false,
+            "muted": false,
+            "autoplay": false
+          }
+        }
+      ]
+    },
+    "seo": {
+      "image": {
+        "_type": "Epic Store Image"
+      },
+      "twitter": {
+        "_type": "SEO Twitter Metadata"
+      },
+      "_type": "Epic Store Product SEO",
+      "og": {
+        "_type": "SEO OG Metadata"
+      }
+    },
+    "gallery": {
+      "_type": "Diesel Gallery"
+    }
+  },
+  "hideMeta": false,
+  "namespace": "bd8a7e894699493fb21503837f7b66c5",
+  "_title": "Shadowrun Collection",
+  "ageGate": {
+    "regionRestrictions": [
+      {
+        "country": "KR",
+        "ageLimit": 18,
+        "_type": "Epic Store Age Gate Region"
+      }
+    ],
+    "hasAgeGate": false,
+    "_type": "Epic Store Age Gate"
+  },
+  "theme": {
+    "buttonPrimaryBg": "#000000",
+    "accentColor": "#000000",
+    "_type": "Diesel Theme",
+    "colorScheme": "dark"
+  },
+  "_noIndex": false,
+  "_images_": [
+    "https://cdn2.unrealengine.com/egs-shadowrunhongkongextendededition-harebrainedschemes-s1-2560x1440-768923401.jpg",
+    "https://cdn2.unrealengine.com/egs-shadowruncollection-harebrainedschemes-g1a-08-1920x1080-785870757.jpg",
+    "https://cdn2.unrealengine.com/egs-shadowruncollection-harebrainedschemes-g1a-11-1920x1080-785871134.jpg",
+    "https://cdn2.unrealengine.com/egs-shadowruncollection-harebrainedschemes-g1a-07-1920x1080-785870678.jpg",
+    "https://cdn2.unrealengine.com/egs-shadowruncollection-harebrainedschemes-g1a-09-1920x1080-785870879.jpg",
+    "https://cdn2.unrealengine.com/egs-shadowruncollection-harebrainedschemes-g1a-06-1920x1080-785870233.jpg",
+    "https://cdn2.unrealengine.com/landscape-image-shadowcoll-2560x1440-777100077.jpg",
+    "https://cdn2.unrealengine.com/egs-shadowruncollection-harebrainedschemes-g1a-04-1920x1080-785870331.jpg",
+    "https://cdn2.unrealengine.com/egs-shadowrundragonfalldirectorcut-harebrainedschemes-s1-2560x1440-769294674.jpg",
+    "https://cdn2.unrealengine.com/egs-shadowruncollection-harebrainedschemes-g1a-10-1920x1080-785870817.jpg",
+    "https://cdn2.unrealengine.com/egs-shadowrunreturns-harebrainedschemes-s1-2560x1440-768642852.jpg",
+    "https://cdn2.unrealengine.com/logo-400x400-400x400-777098045.png",
+    "https://cdn2.unrealengine.com/egs-shadowruncollection-harebrainedschemes-g1a-03-1920x1080-785870474.jpg",
+    "https://cdn2.unrealengine.com/egs-shadowruncollection-harebrainedschemes-g1a-02-1920x1080-785870323.jpg",
+    "https://cdn2.unrealengine.com/egs-shadowruncollection-harebrainedschemes-g1a-01-1920x1080-785870290.jpg",
+    "https://cdn2.unrealengine.com/egs-shadowruncollection-harebrainedschemes-g1a-05-1920x1080-785870547.jpg"
+  ],
+  "jcr:baseVersion": "a7ca237317f1e7b3a4135d-6edc-42cd-944a-bc5055b1d856",
+  "_urlPattern": "/bundles/shadowrun-collection",
+  "_slug": "shadowrun-collection",
+  "_activeDate": "2020-08-18T17:09:45.287Z",
+  "lastModified": "2020-08-27T14:54:12.843Z",
+  "_locale": "en-US",
+  "_id": "098c5cec-e9ee-4923-b5c3-e89d4dbee8ab"
+}

--- a/test/data/freeGamesPromotions_2020-09-01.json
+++ b/test/data/freeGamesPromotions_2020-09-01.json
@@ -1,0 +1,1360 @@
+{
+  "data": {
+    "Catalog": {
+      "searchStore": {
+        "elements": [
+          {
+            "title": "Into The Breach",
+            "id": "a08681e2143d4c218167e45d76db8de0",
+            "namespace": "5c0d568c71174cff8026db2606771d96",
+            "description": "Into The Breach",
+            "effectiveDate": "2019-12-19T16:00:00.000Z",
+            "keyImages": [
+              {
+                "type": "DieselStoreFrontWide",
+                "url": "https://cdn1.epicgames.com/undefined/offer/EGS_SubsetGames_IntotheBreach_S1-2560x1440-dba55f96ffe7af34552ed2215f921bdc.jpg"
+              },
+              {
+                "type": "DieselStoreFrontTall",
+                "url": "https://cdn1.epicgames.com/undefined/offer/EGS_SubsetGames_IntotheBreach_S2-1280x1440-22e899c71d5a2bf7bc9353cc3f6e46d2.jpg"
+              },
+              {
+                "type": "DieselGameBoxLogo",
+                "url": "https://cdn1.epicgames.com/undefined/offer/EGS_SubsetGames_IntotheBreach_IC1-200x200-49a3bf4ab351e9aa255e2e52c8368346.png"
+              },
+              {
+                "type": "OfferImageTall",
+                "url": "https://cdn1.epicgames.com/undefined/offer/EGS_SubsetGames_IntotheBreach_S2-1280x1440-22e899c71d5a2bf7bc9353cc3f6e46d2.jpg"
+              },
+              {
+                "type": "Thumbnail",
+                "url": "https://cdn1.epicgames.com/5c0d568c71174cff8026db2606771d96/offer/EGS_SubsetGames_IntotheBreach_IC2-128x128-c12d3fbc49d67a6faee2d2e2bd7f945d.png"
+              },
+              {
+                "type": "CodeRedemption_340x440",
+                "url": "https://cdn1.epicgames.com/5c0d568c71174cff8026db2606771d96/offer/EGS_SubsetGames_IntotheBreach_S4-510x680-8a865e9778acb1745f4d70a6411ac370.jpg"
+              },
+              {
+                "type": "OfferImageWide",
+                "url": "https://cdn1.epicgames.com/undefined/offer/EGS_SubsetGames_IntotheBreach_S1-2560x1440-dba55f96ffe7af34552ed2215f921bdc.jpg"
+              }
+            ],
+            "seller": {
+              "id": "o-y2xjbnp5qy433qzldqbvncb3n8z3l6",
+              "name": "Subset Games"
+            },
+            "productSlug": "into-the-breach/home",
+            "urlSlug": "blobfishgeneralaudience",
+            "url": null,
+            "items": [
+              {
+                "id": "2b19e544e510468a96a4f918a00d52e9",
+                "namespace": "5c0d568c71174cff8026db2606771d96"
+              }
+            ],
+            "customAttributes": [
+              {
+                "key": "com.epicgames.app.blacklist",
+                "value": "{}"
+              },
+              {
+                "key": "publisherName",
+                "value": "Subset Games"
+              },
+              {
+                "key": "com.epicgames.app.productSlug",
+                "value": "into-the-breach/home"
+              }
+            ],
+            "categories": [
+              {
+                "path": "freegames"
+              },
+              {
+                "path": "games"
+              },
+              {
+                "path": "games/edition/base"
+              },
+              {
+                "path": "games/edition"
+              },
+              {
+                "path": "applications"
+              }
+            ],
+            "tags": [
+              {
+                "id": "1370"
+              },
+              {
+                "id": "1386"
+              },
+              {
+                "id": "1083"
+              },
+              {
+                "id": "1115"
+              },
+              {
+                "id": "9547"
+              }
+            ],
+            "price": {
+              "totalPrice": {
+                "discountPrice": 1499,
+                "originalPrice": 1499,
+                "voucherDiscount": 0,
+                "discount": 0,
+                "currencyCode": "USD",
+                "currencyInfo": {
+                  "decimals": 2
+                },
+                "fmtPrice": {
+                  "originalPrice": "$14.99",
+                  "discountPrice": "$14.99",
+                  "intermediatePrice": "$14.99"
+                }
+              },
+              "lineOffers": [
+                {
+                  "appliedRules": []
+                }
+              ]
+            },
+            "promotions": {
+              "promotionalOffers": [],
+              "upcomingPromotionalOffers": [
+                {
+                  "promotionalOffers": [
+                    {
+                      "startDate": "2020-09-10T15:00:00.000Z",
+                      "endDate": "2020-09-24T15:00:00.000Z",
+                      "discountSetting": {
+                        "discountType": "PERCENTAGE",
+                        "discountPercentage": 50
+                      }
+                    },
+                    {
+                      "startDate": "2020-09-03T15:00:00.000Z",
+                      "endDate": "2020-09-10T15:00:00.000Z",
+                      "discountSetting": {
+                        "discountType": "PERCENTAGE",
+                        "discountPercentage": 0
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "title": "Shadowrun Collection",
+            "id": "c5cb60ecc6554c6a8d9a682b87ab04bb",
+            "namespace": "bd8a7e894699493fb21503837f7b66c5",
+            "description": "Shadowrun Collection",
+            "effectiveDate": "2020-08-27T15:00:00.000Z",
+            "keyImages": [
+              {
+                "type": "OfferImageWide",
+                "url": "https://cdn1.epicgames.com/undefined/offer/Landscape Image_Shadowcoll-2560x1440-6418de83cb9ac99fc8eeb574ea65aac3.jpg"
+              },
+              {
+                "type": "OfferImageTall",
+                "url": "https://cdn1.epicgames.com/undefined/offer/Portrait image1200x1600-1200x1600-791ecaaee8dcdfc1c796c5dd21783e06.jpg"
+              },
+              {
+                "type": "CodeRedemption_340x440",
+                "url": "https://cdn1.epicgames.com/undefined/offer/Portrait image1200x1600-1200x1600-791ecaaee8dcdfc1c796c5dd21783e06.jpg"
+              },
+              {
+                "type": "DieselStoreFrontTall",
+                "url": "https://cdn1.epicgames.com/undefined/offer/Portrait image1200x1600-1200x1600-791ecaaee8dcdfc1c796c5dd21783e06.jpg"
+              },
+              {
+                "type": "DieselStoreFrontWide",
+                "url": "https://cdn1.epicgames.com/undefined/offer/Landscape Image_Shadowcoll-2560x1440-6418de83cb9ac99fc8eeb574ea65aac3.jpg"
+              },
+              {
+                "type": "Thumbnail",
+                "url": "https://cdn1.epicgames.com/bd8a7e894699493fb21503837f7b66c5/offer/EGS_ShadowrunCollection_HarebrainedSchemes_G1A_00-1920x1080-17feba164bafaad2306b5afc98e55783.jpg"
+              }
+            ],
+            "seller": {
+              "id": "o-tjvfg6rejs6h86qa7k9aa64rrgbxxb",
+              "name": "Paradox Interactive"
+            },
+            "productSlug": "shadowrun-collection",
+            "urlSlug": "shadowrun-collection",
+            "url": null,
+            "items": [
+              {
+                "id": "794469cd9a0441b58330e74458640d03",
+                "namespace": "0d66818e2304485f8dc3ae90c8b622b4"
+              },
+              {
+                "id": "1f469cce8b4945ca87411bbc36880080",
+                "namespace": "805a1b31b65f4c3db221ab242f894482"
+              },
+              {
+                "id": "be5db329712c4b4f8b4094a4c0003408",
+                "namespace": "a8400ce7530e4479b32dcaf0e92fce57"
+              }
+            ],
+            "customAttributes": [
+              {
+                "key": "com.epicgames.app.blacklist",
+                "value": "[]"
+              },
+              {
+                "key": "publisherName",
+                "value": "Paradox Interactive"
+              },
+              {
+                "key": "developerName",
+                "value": "Harebrained Schemes"
+              },
+              {
+                "key": "com.epicgames.app.productSlug",
+                "value": "shadowrun-collection"
+              }
+            ],
+            "categories": [
+              {
+                "path": "bundles"
+              },
+              {
+                "path": "freegames"
+              },
+              {
+                "path": "games"
+              },
+              {
+                "path": "bundles/games"
+              },
+              {
+                "path": "applications"
+              }
+            ],
+            "tags": [
+              {
+                "id": "1216"
+              },
+              {
+                "id": "1367"
+              },
+              {
+                "id": "1336"
+              },
+              {
+                "id": "9547"
+              }
+            ],
+            "price": {
+              "totalPrice": {
+                "discountPrice": 0,
+                "originalPrice": 4999,
+                "voucherDiscount": 0,
+                "discount": 4999,
+                "currencyCode": "USD",
+                "currencyInfo": {
+                  "decimals": 2
+                },
+                "fmtPrice": {
+                  "originalPrice": "$49.99",
+                  "discountPrice": "0",
+                  "intermediatePrice": "0"
+                }
+              },
+              "lineOffers": [
+                {
+                  "appliedRules": [
+                    {
+                      "id": "2a5cee52f133463c8f6cb94b32893cc8",
+                      "endDate": "2020-09-03T15:00:00.000Z",
+                      "discountSetting": {
+                        "discountType": "PERCENTAGE"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "promotions": {
+              "promotionalOffers": [
+                {
+                  "promotionalOffers": [
+                    {
+                      "startDate": "2020-08-27T15:00:00.000Z",
+                      "endDate": "2020-09-03T15:00:00.000Z",
+                      "discountSetting": {
+                        "discountType": "PERCENTAGE",
+                        "discountPercentage": 0
+                      }
+                    }
+                  ]
+                }
+              ],
+              "upcomingPromotionalOffers": []
+            }
+          },
+          {
+            "title": "3 out of 10, EP 4: \"Thank You For Being An Asset\"",
+            "id": "00ae234a8e4a4a80b6b3c124ae738372",
+            "namespace": "d6a3cae34c5d4562832610b5b8664576",
+            "description": "3 out of 10, EP 4: \"Thank You For Being An Asset\"",
+            "effectiveDate": "2020-08-27T15:00:00.000Z",
+            "keyImages": [
+              {
+                "type": "OfferImageWide",
+                "url": "https://cdn1.epicgames.com/d6a3cae34c5d4562832610b5b8664576/offer/EGS_3outof10EP4ThankYouForBeingAnAsset_TerriblePostureGamesInc_S1-2560x1440-fcaf73701007096c6abc01415788d4c3.jpg"
+              },
+              {
+                "type": "OfferImageTall",
+                "url": "https://cdn1.epicgames.com/d6a3cae34c5d4562832610b5b8664576/offer/EGS_3outof10EP4ThankYouForBeingAnAsset_TerriblePostureGamesInc_S2-1200x1600-1a465a21d91318bd7d0f6a7b968d4797.jpg"
+              },
+              {
+                "type": "DieselStoreFrontTall",
+                "url": "https://cdn1.epicgames.com/d6a3cae34c5d4562832610b5b8664576/offer/EGS_3outof10EP4ThankYouForBeingAnAsset_TerriblePostureGamesInc_S2-1200x1600-1a465a21d91318bd7d0f6a7b968d4797.jpg"
+              },
+              {
+                "type": "DieselStoreFrontWide",
+                "url": "https://cdn1.epicgames.com/d6a3cae34c5d4562832610b5b8664576/offer/EGS_3outof10EP4ThankYouForBeingAnAsset_TerriblePostureGamesInc_S1-2560x1440-fcaf73701007096c6abc01415788d4c3.jpg"
+              },
+              {
+                "type": "CodeRedemption_340x440",
+                "url": "https://cdn1.epicgames.com/d6a3cae34c5d4562832610b5b8664576/offer/EGS_3outof10EP4ThankYouForBeingAnAsset_TerriblePostureGamesInc_S2-1200x1600-1a465a21d91318bd7d0f6a7b968d4797.jpg"
+              },
+              {
+                "type": "Thumbnail",
+                "url": "https://cdn1.epicgames.com/d6a3cae34c5d4562832610b5b8664576/offer/EGS_3outof10EP4ThankYouForBeingAnAsset_TerriblePostureGamesInc_S2-1200x1600-1a465a21d91318bd7d0f6a7b968d4797.jpg"
+              }
+            ],
+            "seller": {
+              "id": "o-2yllrrr7vufkhal9nk3cswwgug977c",
+              "name": "Terrible Posture Games, Inc."
+            },
+            "productSlug": "3-out-of-10-ep-4",
+            "urlSlug": "3-out-of-10-ep",
+            "url": null,
+            "items": [
+              {
+                "id": "821516f0ed8448b89b7fe0e1e4628e03",
+                "namespace": "d6a3cae34c5d4562832610b5b8664576"
+              }
+            ],
+            "customAttributes": [
+              {
+                "key": "com.epicgames.app.blacklist",
+                "value": "KR"
+              },
+              {
+                "key": "developerName",
+                "value": "Terrible Posture Games, Inc."
+              },
+              {
+                "key": "com.epicgames.app.productSlug",
+                "value": "3-out-of-10-ep-4"
+              }
+            ],
+            "categories": [
+              {
+                "path": "freegames"
+              },
+              {
+                "path": "games"
+              },
+              {
+                "path": "games/edition"
+              },
+              {
+                "path": "games/edition/base"
+              },
+              {
+                "path": "applications"
+              }
+            ],
+            "tags": [
+              {
+                "id": "1381"
+              },
+              {
+                "id": "9547"
+              },
+              {
+                "id": "1116"
+              },
+              {
+                "id": "9549"
+              },
+              {
+                "id": "1117"
+              }
+            ],
+            "price": {
+              "totalPrice": {
+                "discountPrice": 0,
+                "originalPrice": 0,
+                "voucherDiscount": 0,
+                "discount": 0,
+                "currencyCode": "USD",
+                "currencyInfo": {
+                  "decimals": 2
+                },
+                "fmtPrice": {
+                  "originalPrice": "0",
+                  "discountPrice": "0",
+                  "intermediatePrice": "0"
+                }
+              },
+              "lineOffers": [
+                {
+                  "appliedRules": []
+                }
+              ]
+            },
+            "promotions": null
+          },
+          {
+            "title": "HITMAN",
+            "id": "e8efad3d47a14284867fef2c347c321d",
+            "namespace": "3c06b15a8a2845c0b725d4f952fe00aa",
+            "description": "HITMAN",
+            "effectiveDate": "2020-08-27T15:00:00.000Z",
+            "keyImages": [
+              {
+                "type": "OfferImageWide",
+                "url": "https://cdn1.epicgames.com/3c06b15a8a2845c0b725d4f952fe00aa/offer/EGS_IOInteractiveAS_HITMANTheCompleteFirstSeason_S3-1360x766-6becb0825ddf48b1511a6f8e9be02f9f.jpg"
+              },
+              {
+                "type": "OfferImageTall",
+                "url": "https://cdn1.epicgames.com/3c06b15a8a2845c0b725d4f952fe00aa/offer/EGS_IOInteractiveAS_HITMANTheCompleteFirstSeason_S2-860x1148-cb3bc2b2ef92dd133e1baa2edde5e232.jpg"
+              },
+              {
+                "type": "Thumbnail",
+                "url": "https://cdn1.epicgames.com/3c06b15a8a2845c0b725d4f952fe00aa/offer/EGS_IOInteractiveAS_HITMANTheCompleteFirstSeason_S2-860x1148-cb3bc2b2ef92dd133e1baa2edde5e232.jpg"
+              },
+              {
+                "type": "CodeRedemption_340x440",
+                "url": "https://cdn1.epicgames.com/3c06b15a8a2845c0b725d4f952fe00aa/offer/EGS_IOInteractiveAS_HITMANTheCompleteFirstSeason_S2-860x1148-cb3bc2b2ef92dd133e1baa2edde5e232.jpg"
+              },
+              {
+                "type": "DieselStoreFrontTall",
+                "url": "https://cdn1.epicgames.com/3c06b15a8a2845c0b725d4f952fe00aa/offer/EGS_IOInteractiveAS_HITMANTheCompleteFirstSeason_S2-860x1148-cb3bc2b2ef92dd133e1baa2edde5e232.jpg"
+              },
+              {
+                "type": "DieselStoreFrontWide",
+                "url": "https://cdn1.epicgames.com/3c06b15a8a2845c0b725d4f952fe00aa/offer/EGS_IOInteractiveAS_HITMANTheCompleteFirstSeason_S3-1360x766-6becb0825ddf48b1511a6f8e9be02f9f.jpg"
+              }
+            ],
+            "seller": {
+              "id": "o-ank8fbh38u9uzqbag2a5yt5xexb4yr",
+              "name": "IO Interactive"
+            },
+            "productSlug": "hitman/standard-edition",
+            "urlSlug": "hitman-standard",
+            "url": null,
+            "items": [
+              {
+                "id": "0a73eaedcac84bd28b567dbec764c5cb",
+                "namespace": "3c06b15a8a2845c0b725d4f952fe00aa"
+              }
+            ],
+            "customAttributes": [
+              {
+                "key": "com.epicgames.app.blacklist",
+                "value": "[]"
+              },
+              {
+                "key": "developerName",
+                "value": "IO Interactive"
+              },
+              {
+                "key": "com.epicgames.app.productSlug",
+                "value": "hitman/standard-edition"
+              }
+            ],
+            "categories": [
+              {
+                "path": "freegames"
+              },
+              {
+                "path": "games"
+              },
+              {
+                "path": "games/edition"
+              },
+              {
+                "path": "games/edition/base"
+              },
+              {
+                "path": "applications"
+              }
+            ],
+            "tags": [
+              {
+                "id": "1216"
+              },
+              {
+                "id": "1336"
+              },
+              {
+                "id": "1210"
+              },
+              {
+                "id": "1370"
+              },
+              {
+                "id": "9547"
+              },
+              {
+                "id": "1084"
+              },
+              {
+                "id": "1342"
+              }
+            ],
+            "price": {
+              "totalPrice": {
+                "discountPrice": 0,
+                "originalPrice": 5999,
+                "voucherDiscount": 0,
+                "discount": 5999,
+                "currencyCode": "USD",
+                "currencyInfo": {
+                  "decimals": 2
+                },
+                "fmtPrice": {
+                  "originalPrice": "$59.99",
+                  "discountPrice": "0",
+                  "intermediatePrice": "0"
+                }
+              },
+              "lineOffers": [
+                {
+                  "appliedRules": [
+                    {
+                      "id": "2d600b05f5d64833aa24faee7406da58",
+                      "endDate": "2020-09-03T15:00:00.000Z",
+                      "discountSetting": {
+                        "discountType": "PERCENTAGE"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "promotions": {
+              "promotionalOffers": [
+                {
+                  "promotionalOffers": [
+                    {
+                      "startDate": "2020-08-27T15:00:00.000Z",
+                      "endDate": "2020-09-03T15:00:00.000Z",
+                      "discountSetting": {
+                        "discountType": "PERCENTAGE",
+                        "discountPercentage": 0
+                      }
+                    }
+                  ]
+                }
+              ],
+              "upcomingPromotionalOffers": []
+            }
+          }
+        ],
+        "paging": {
+          "count": 1000,
+          "total": 4
+        }
+      }
+    }
+  },
+  "extensions": {
+    "cacheControl": {
+      "version": 1,
+      "hints": [
+        {
+          "path": [
+            "Catalog"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            0,
+            "keyImages"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            0,
+            "seller"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            0,
+            "items"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            0,
+            "customAttributes"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            0,
+            "categories"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            0,
+            "tags"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            0,
+            "price"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            0,
+            "promotions"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            1,
+            "keyImages"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            1,
+            "seller"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            1,
+            "items"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            1,
+            "customAttributes"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            1,
+            "categories"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            1,
+            "tags"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            1,
+            "price"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            1,
+            "promotions"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            2,
+            "keyImages"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            2,
+            "seller"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            2,
+            "items"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            2,
+            "customAttributes"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            2,
+            "categories"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            2,
+            "tags"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            2,
+            "price"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            2,
+            "promotions"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            3,
+            "keyImages"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            3,
+            "seller"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            3,
+            "items"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            3,
+            "customAttributes"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            3,
+            "categories"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            3,
+            "tags"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            3,
+            "price"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            3,
+            "promotions"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "paging"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            3,
+            "price",
+            "totalPrice"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            3,
+            "price",
+            "totalPrice",
+            "currencyInfo"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            3,
+            "price",
+            "totalPrice",
+            "fmtPrice"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            3,
+            "price",
+            "lineOffers"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            3,
+            "price",
+            "lineOffers",
+            0,
+            "appliedRules"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            3,
+            "price",
+            "lineOffers",
+            0,
+            "appliedRules",
+            0,
+            "discountSetting"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            0,
+            "price",
+            "totalPrice"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            0,
+            "price",
+            "totalPrice",
+            "currencyInfo"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            0,
+            "price",
+            "totalPrice",
+            "fmtPrice"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            0,
+            "price",
+            "lineOffers"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            0,
+            "price",
+            "lineOffers",
+            0,
+            "appliedRules"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            1,
+            "price",
+            "totalPrice"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            1,
+            "price",
+            "totalPrice",
+            "currencyInfo"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            1,
+            "price",
+            "totalPrice",
+            "fmtPrice"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            1,
+            "price",
+            "lineOffers"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            1,
+            "price",
+            "lineOffers",
+            0,
+            "appliedRules"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            1,
+            "price",
+            "lineOffers",
+            0,
+            "appliedRules",
+            0,
+            "discountSetting"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            2,
+            "price",
+            "totalPrice"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            2,
+            "price",
+            "totalPrice",
+            "currencyInfo"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            2,
+            "price",
+            "totalPrice",
+            "fmtPrice"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            2,
+            "price",
+            "lineOffers"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            2,
+            "price",
+            "lineOffers",
+            0,
+            "appliedRules"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            3,
+            "promotions",
+            "promotionalOffers"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            3,
+            "promotions",
+            "promotionalOffers",
+            0,
+            "promotionalOffers"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            3,
+            "promotions",
+            "promotionalOffers",
+            0,
+            "promotionalOffers",
+            0,
+            "discountSetting"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            3,
+            "promotions",
+            "upcomingPromotionalOffers"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            1,
+            "promotions",
+            "promotionalOffers"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            1,
+            "promotions",
+            "promotionalOffers",
+            0,
+            "promotionalOffers"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            1,
+            "promotions",
+            "promotionalOffers",
+            0,
+            "promotionalOffers",
+            0,
+            "discountSetting"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            1,
+            "promotions",
+            "upcomingPromotionalOffers"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            0,
+            "promotions",
+            "promotionalOffers"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            0,
+            "promotions",
+            "upcomingPromotionalOffers"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            0,
+            "promotions",
+            "upcomingPromotionalOffers",
+            0,
+            "promotionalOffers"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            0,
+            "promotions",
+            "upcomingPromotionalOffers",
+            0,
+            "promotionalOffers",
+            0,
+            "discountSetting"
+          ],
+          "maxAge": 0
+        },
+        {
+          "path": [
+            "Catalog",
+            "searchStore",
+            "elements",
+            0,
+            "promotions",
+            "upcomingPromotionalOffers",
+            0,
+            "promotionalOffers",
+            1,
+            "discountSetting"
+          ],
+          "maxAge": 0
+        }
+      ]
+    }
+  }
+}

--- a/test/data/products_hitman_2020-09-01.json
+++ b/test/data/products_hitman_2020-09-01.json
@@ -1,0 +1,1293 @@
+{
+  "productRatings": {
+    "ratings": [
+      {
+        "image": {
+          "src": "https://cdn2.unrealengine.com/egs-hitman-iointeractiveas-ra1-370x208-370x208-829765488.png",
+          "_type": "Epic Store Image"
+        },
+        "countryCodes": "US,CA,MX",
+        "_type": "Epic Store Rating",
+        "title": "MATURE 17 +"
+      },
+      {
+        "image": {
+          "src": "https://cdn2.unrealengine.com/Diesel%2Fproduct%2Fratings%2FPEGI_18_Rating-208x254-f12521f5a5231d533ff539144709543cdf68f031.jpg",
+          "_type": "Epic Store Image"
+        },
+        "countryCodes": "AT,BE,BG,HR,CY,CZ,DK,EE,FI,FR,GR,HU,IE,IT,LV,LT,LU,MT,NL,PL,PT,RO,SK,SI,ES,SE,GB",
+        "_type": "Epic Store Rating",
+        "title": "PEGI 18"
+      },
+      {
+        "image": {
+          "src": "https://cdn2.unrealengine.com/Diesel%2Fproduct%2Fratings%2FUSK_18-400x400-7ac38d8b4b29de7c5f10a52ebf17f124e361279e.png",
+          "_type": "Epic Store Image"
+        },
+        "countryCodes": "DE",
+        "_type": "Epic Store Rating",
+        "title": "USK ab 18"
+      },
+      {
+        "image": {
+          "src": "https://cdn2.unrealengine.com/18-v-l-d-c-540x117-672303047.png",
+          "_type": "Epic Store Image"
+        },
+        "countryCodes": "KR",
+        "_type": "Epic Store Rating",
+        "title": "청소년이용불가"
+      },
+      {
+        "image": {
+          "src": "https://cdn2.unrealengine.com/Diesel%2Fproduct%2Fratings%2F800px-CERO_Z.svg-800x984-ffd454acb3d6f8fac8bdf1bf2a2d01da0d79f858.png",
+          "_type": "Epic Store Image"
+        },
+        "countryCodes": "JP",
+        "_type": "Epic Store Rating",
+        "title": "CERO Z"
+      }
+    ],
+    "_type": "Epic Store Product Ratings"
+  },
+  "disableNewAddons": true,
+  "modMarketplaceEnabled": false,
+  "_title": "hitman",
+  "regionBlock": "",
+  "_noIndex": false,
+  "_images_": [
+    "https://cdn2.unrealengine.com/Diesel%2Fproduct%2Fratings%2FUSK_18-400x400-7ac38d8b4b29de7c5f10a52ebf17f124e361279e.png",
+    "https://cdn2.unrealengine.com/Diesel%2Fproduct%2Fratings%2FPEGI_18_Rating-208x254-f12521f5a5231d533ff539144709543cdf68f031.jpg",
+    "https://cdn2.unrealengine.com/Diesel%2Fproduct%2Fratings%2F800px-CERO_Z.svg-800x984-ffd454acb3d6f8fac8bdf1bf2a2d01da0d79f858.png",
+    "https://cdn2.unrealengine.com/18-v-l-d-c-540x117-672303047.png",
+    "https://cdn2.unrealengine.com/egs-hitman-iointeractiveas-ra1-370x208-370x208-829765488.png"
+  ],
+  "productName": "Hitman 2016",
+  "jcr:isCheckedOut": true,
+  "namespace": "3c06b15a8a2845c0b725d4f952fe00aa",
+  "theme": {
+    "_type": "Diesel Theme"
+  },
+  "reviewOptOut": false,
+  "jcr:baseVersion": "a7ca237317f1e70c6be6ee-ac48-4ffa-8863-cd50adc9bed9",
+  "externalNavLinks": {
+    "_type": "Epic Store Links"
+  },
+  "_urlPattern": "/productv2/hitman",
+  "_slug": "hitman",
+  "_activeDate": "2020-02-04T14:41:51.564Z",
+  "lastModified": "2020-08-24T19:36:27.729Z",
+  "_locale": "en-US",
+  "_id": "1d6ce96e-6985-4739-8ced-52fff723eea6",
+  "pages": [
+    {
+      "productRatings": {
+        "ratings": [
+          {
+            "image": {
+              "src": "https://cdn2.unrealengine.com/egs-hitman-iointeractiveas-ra1-370x208-370x208-829765488.png",
+              "_type": "Epic Store Image"
+            },
+            "countryCodes": "US,CA,MX",
+            "_type": "Epic Store Rating",
+            "title": "MATURE 17 +"
+          },
+          {
+            "image": {
+              "src": "https://cdn2.unrealengine.com/Diesel%2Fproduct%2Fratings%2FPEGI_18_Rating-208x254-f12521f5a5231d533ff539144709543cdf68f031.jpg",
+              "_type": "Epic Store Image"
+            },
+            "countryCodes": "AT,BE,BG,HR,CY,CZ,DK,EE,FI,FR,GR,HU,IE,IT,LV,LT,LU,MT,NL,PL,PT,RO,SK,SI,ES,SE,GB",
+            "_type": "Epic Store Rating",
+            "title": "PEGI 18"
+          },
+          {
+            "image": {
+              "src": "https://cdn2.unrealengine.com/Diesel%2Fproduct%2Fratings%2FUSK_18-400x400-7ac38d8b4b29de7c5f10a52ebf17f124e361279e.png",
+              "_type": "Epic Store Image"
+            },
+            "countryCodes": "DE",
+            "_type": "Epic Store Rating",
+            "title": "USK ab 18"
+          },
+          {
+            "image": {
+              "src": "https://cdn2.unrealengine.com/18-v-l-d-c-540x117-672303047.png",
+              "_type": "Epic Store Image"
+            },
+            "countryCodes": "KR",
+            "_type": "Epic Store Rating",
+            "title": "청소년이용불가"
+          },
+          {
+            "image": {
+              "src": "https://cdn2.unrealengine.com/Diesel%2Fproduct%2Fratings%2F800px-CERO_Z.svg-800x984-ffd454acb3d6f8fac8bdf1bf2a2d01da0d79f858.png",
+              "_type": "Epic Store Image"
+            },
+            "countryCodes": "JP",
+            "_type": "Epic Store Rating",
+            "title": "CERO Z"
+          }
+        ],
+        "_type": "Epic Store Product Ratings"
+      },
+      "disableNewAddons": true,
+      "modMarketplaceEnabled": false,
+      "_title": "standard-edition",
+      "regionBlock": "",
+      "_noIndex": false,
+      "_images_": [
+        "https://cdn2.unrealengine.com/egs-hitman-iointeractiveas-ic3-200x200-551403813.png",
+        "https://cdn2.unrealengine.com/egs-hitmangameoftheyearupgrade-iointeractiveas-dlc-s1-2560x1440-623108052.jpg",
+        "https://cdn2.unrealengine.com/Diesel%2Fproductv2%2Fhitman%2Fhome%2FEGS_IOInteractiveAS_HITMANTheCompleteFirstSeason_G1A_02-1920x1080-358b2bef1a14735c36266bda2ec57d9dab95bb71.jpg",
+        "https://cdn2.unrealengine.com/Diesel%2Fproductv2%2Fhitman%2Fhome%2FEGS_IOInteractiveAS_HITMANTheCompleteFirstSeason_IC1-200x200-1b87a2cf091a73488e4b5d743144db480f1ff7e6.png",
+        "https://cdn2.unrealengine.com/Diesel%2Fproductv2%2Fhitman%2Fhome%2FEGS_IOInteractiveAS_HITMANTheCompleteFirstSeason_S2-860x1148-90e70a51380bd7f19f78154d45f460707499e3ad.jpg",
+        "https://cdn2.unrealengine.com/Diesel%2Fproductv2%2Fhitman%2Fhome%2FEGS_IOInteractiveAS_HITMANTheCompleteFirstSeason_S1-2560x1440-ee0a95f41d75bdb9a2661ebdea9b349c68ce35d2.jpg",
+        "https://cdn2.unrealengine.com/Diesel%2Fproductv2%2Fhitman%2Fhome%2FEGS_IOInteractiveAS_HITMANTheCompleteFirstSeason_G1A_01-1920x1080-7a0feff0ff3bc28827a99f45b655042f7f9a810b.jpg",
+        "https://cdn2.unrealengine.com/Diesel%2Fproductv2%2Fhitman%2Fhome%2FEGS_IOInteractiveAS_HITMANTheCompleteFirstSeason_S3-1360x766-11872ddd2ff281a9fd221e6fa70655cd7f9643c5.jpg",
+        "https://cdn2.unrealengine.com/Diesel%2Fproductv2%2Fhitman%2Fhome%2FEGS_IOInteractiveAS_HITMANTheCompleteFirstSeason_G1A_00-1920x1080-badcc937b70155e57bf86e075283ed1060962bb7.jpg",
+        "https://cdn2.unrealengine.com/Diesel%2Fproductv2%2Fhitman%2Fhome%2FEGS_IOInteractiveAS_HITMANTheCompleteFirstSeason_G1A_03-1920x1080-539bda3e1756c22417d7cb754b6fabd0ae4672ba.jpg"
+      ],
+      "productName": "Hitman 2016",
+      "jcr:isCheckedOut": true,
+      "namespace": "3c06b15a8a2845c0b725d4f952fe00aa",
+      "theme": {
+        "buttonPrimaryBg": "#FFFFFF",
+        "customPrimaryBg": "#000000",
+        "accentColor": "#FFFFFF",
+        "_type": "Diesel Theme",
+        "colorScheme": "dark"
+      },
+      "reviewOptOut": false,
+      "jcr:baseVersion": "a7ca237317f1e74ac78de1-9002-4fda-a397-1c1dec155d8f",
+      "externalNavLinks": {
+        "_type": "Epic Store Links"
+      },
+      "_urlPattern": "/productv2/hitman/standard-edition",
+      "_slug": "standard-edition",
+      "_activeDate": "2020-02-04T14:45:10.836Z",
+      "lastModified": "2020-08-27T14:47:26.721Z",
+      "_locale": "en-US",
+      "_id": "4e6879fa-e30a-45da-a459-aab53bc8a4cd",
+      "offer": {
+        "regionRestrictions": {
+          "_type": "Store Region Filtering"
+        },
+        "_type": "Diesel Offer",
+        "namespace": "3c06b15a8a2845c0b725d4f952fe00aa",
+        "id": "e8efad3d47a14284867fef2c347c321d",
+        "type": "",
+        "hasOffer": true
+      },
+      "item": {
+        "catalogId": "",
+        "appName": "",
+        "_type": "Diesel Product Item",
+        "namespace": "",
+        "hasItem": false
+      },
+      "data": {
+        "productLinks": {
+          "_type": "Diesel Product Lins"
+        },
+        "socialLinks": {
+          "linkTwitter": "https://twitter.com/hitman",
+          "linkTwitch": "http://www.twitch.tv/hitman",
+          "linkFacebook": "https://www.facebook.com/hitman",
+          "linkYoutube": "https://www.youtube.com/user/hitman?hl=en&gl=US",
+          "_type": "Diesel Social Links",
+          "linkReddit": "https://www.reddit.com/r/HiTMAN/",
+          "title": "Follow HITMAN",
+          "linkHomepage": "https://hitman.com"
+        },
+        "requirements": {
+          "languages": [
+            "AUDIO - English",
+            "TEXT - English, French, German, Italian, Spanish - Spain, Japanese, Polish, Portuguese - Brazil, Russian, Chinese - Simplified"
+          ],
+          "systems": [
+            {
+              "_type": "Diesel System Detail",
+              "systemType": "Windows",
+              "details": [
+                {
+                  "_type": "Diesel System Detail Item",
+                  "title": "OS",
+                  "minimum": "OS 64-bit Windows 7",
+                  "recommended": "OS 64-bit Windows 7 / 64-bit Windows 8 (8.1) or Windows 10"
+                },
+                {
+                  "_type": "Diesel System Detail Item",
+                  "title": "Processor",
+                  "minimum": "Intel CPU Core i5-2500K 3.3GHz / AMD CPU Phenom II X4 940",
+                  "recommended": "Intel CPU Core i7 3770 3,4 GHz / AMD CPU AMD FX-8350 4 GHz"
+                },
+                {
+                  "_type": "Diesel System Detail Item",
+                  "title": "Memory",
+                  "minimum": "8",
+                  "recommended": "8"
+                },
+                {
+                  "_type": "Diesel System Detail Item",
+                  "title": "Graphics",
+                  "minimum": "NVIDIA GeForce GTX 660 / Radeon HD 7870",
+                  "recommended": "Nvidia GPU GeForce GTX 770 / AMD GPU Radeon R9 290"
+                },
+                {
+                  "_type": "Diesel System Detail Item",
+                  "title": "DirectX",
+                  "minimum": "11",
+                  "recommended": "11"
+                },
+                {
+                  "_type": "Diesel System Detail Item",
+                  "title": "Storage",
+                  "minimum": "50 ",
+                  "recommended": "50"
+                }
+              ]
+            }
+          ],
+          "_type": "Diesel System Details",
+          "rating": {
+            "_type": "Diesel Rating"
+          }
+        },
+        "navOrder": 2,
+        "footer": {
+          "_type": "Diesel Product Footer",
+          "copy": "HITMAN™ © 2020 IO Interactive A/S. Published by IO Interactive A/S. IO INTERACTIVE, the IO logo, HITMAN™, the HITMAN™ logos, and WORLD OF ASSASSINATION are trademarks or registered trademarks owned by or exclusively licensed to IO Interactive A/S. All rights reserved. All other trademarks are the property of their respective owners.",
+          "privacyPolicyLink": {
+            "src": "https://www.ioi.dk/privacy-policy/",
+            "_type": "Diesel Link",
+            "title": "IO Interactive A/S Privacy Policy"
+          }
+        },
+        "_type": "Diesel Product Detail",
+        "about": {
+          "image": {
+            "src": "https://cdn2.unrealengine.com/Diesel%2Fproductv2%2Fhitman%2Fhome%2FEGS_IOInteractiveAS_HITMANTheCompleteFirstSeason_S2-860x1148-90e70a51380bd7f19f78154d45f460707499e3ad.jpg",
+            "_type": "Diesel Image"
+          },
+          "developerAttribution": "IO Interactive A/S",
+          "_type": "Diesel Product About",
+          "publisherAttribution": "IO Interactive A/S",
+          "description": "Featuring all of the Season One locations and episodes from the Prologue, Paris, Sapienza, Marrakesh, Bangkok, Colorado, and Hokkaido. As Agent 47, you will perform contract hits on powerful, high-profile targets in an intense spy-thriller story across a world of assassination.\n\nAs you complete missions and contracts new weapons, items and equipment become available for use across all locations. Learn the tools of the trade as you earn your way to Silent Assassin status.",
+          "shortDescription": "Experiment and have fun in the ultimate playground as Agent 47 to become the master assassin. Travel around the globe to exotic locations and eliminate your targets with everything from a katana or a sniper rifle to an exploding golf ball.",
+          "title": "HITMAN",
+          "developerLogo": {
+            "src": "https://cdn2.unrealengine.com/egs-hitman-iointeractiveas-ic3-200x200-551403813.png",
+            "_type": "Diesel Image"
+          }
+        },
+        "banner": {
+          "showPromotion": false,
+          "_type": "Epic Store Product Banner",
+          "link": {
+            "_type": "Diesel Link"
+          }
+        },
+        "hero": {
+          "logoImage": {
+            "src": "https://cdn2.unrealengine.com/Diesel%2Fproductv2%2Fhitman%2Fhome%2FEGS_IOInteractiveAS_HITMANTheCompleteFirstSeason_IC1-200x200-1b87a2cf091a73488e4b5d743144db480f1ff7e6.png",
+            "_type": "Diesel Image"
+          },
+          "portraitBackgroundImageUrl": "https://cdn2.unrealengine.com/Diesel%2Fproductv2%2Fhitman%2Fhome%2FEGS_IOInteractiveAS_HITMANTheCompleteFirstSeason_S2-860x1148-90e70a51380bd7f19f78154d45f460707499e3ad.jpg",
+          "_type": "Diesel Hero",
+          "action": {
+            "_type": "Diesel Action"
+          },
+          "video": {
+            "loop": false,
+            "_type": "Diesel Video",
+            "hasFullScreen": false,
+            "hasControls": false,
+            "muted": false,
+            "autoplay": false
+          },
+          "isFullBleed": false,
+          "altContentPosition": false,
+          "backgroundImageUrl": "https://cdn2.unrealengine.com/Diesel%2Fproductv2%2Fhitman%2Fhome%2FEGS_IOInteractiveAS_HITMANTheCompleteFirstSeason_S1-2560x1440-ee0a95f41d75bdb9a2661ebdea9b349c68ce35d2.jpg"
+        },
+        "carousel": {
+          "_type": "Diesel Carousel",
+          "items": [
+            {
+              "image": {
+                "src": "https://cdn2.unrealengine.com/Diesel%2Fproductv2%2Fhitman%2Fhome%2FEGS_IOInteractiveAS_HITMANTheCompleteFirstSeason_S3-1360x766-11872ddd2ff281a9fd221e6fa70655cd7f9643c5.jpg",
+                "_type": "Diesel Image"
+              },
+              "_type": "Diesel Carousel Item - Image OR Video",
+              "video": {
+                "loop": false,
+                "_type": "Diesel Video",
+                "hasFullScreen": false,
+                "hasControls": false,
+                "muted": false,
+                "autoplay": false
+              }
+            }
+          ]
+        },
+        "editions": {
+          "_type": "Epic Store Editions",
+          "enableImages": false
+        },
+        "meta": {
+          "releaseDate": "2020-03-13T15:00:00.000Z",
+          "_type": "Epic Store Meta",
+          "publisher": [
+            "IO Interactive A/S"
+          ],
+          "logo": {
+            "_type": "Epic Store Image"
+          },
+          "developer": [
+            "IO Interactive A/S"
+          ],
+          "platform": [
+            "Windows"
+          ],
+          "tags": [
+            "ACTION",
+            "STEALTH"
+          ]
+        },
+        "markdown": {
+          "_type": "Epic Store Markdown"
+        },
+        "dlc": {
+          "contingentOffer": {
+            "regionRestrictions": {
+              "_type": "Store Region Filtering"
+            },
+            "_type": "Diesel Offer",
+            "hasOffer": false
+          },
+          "_type": "Epic Store DLC",
+          "dlc": [
+            {
+              "regionRestrictions": {
+                "_type": "Store Region Filtering"
+              },
+              "image": {
+                "src": "https://cdn2.unrealengine.com/egs-hitmangameoftheyearupgrade-iointeractiveas-dlc-s1-2560x1440-623108052.jpg",
+                "_type": "Diesel Image"
+              },
+              "_type": "Product DLC",
+              "namespace": "3c06b15a8a2845c0b725d4f952fe00aa",
+              "description": "Upgrade your copy of HITMAN to the GOTY Edition now and get immediate access to the Patient Zero campaign plus all the other new content included in the GOTY Edition",
+              "offerId": "e573ab5b700a418bade0407694c125d6",
+              "tag": "dlc",
+              "title": "HITMAN - Game of the Year Upgrade",
+              "type": "addon",
+              "slug": "product/hitman/game-of-the-year-upgrade"
+            }
+          ],
+          "enableImages": true
+        },
+        "seo": {
+          "image": {
+            "_type": "Epic Store Image"
+          },
+          "twitter": {
+            "_type": "SEO Twitter Metadata"
+          },
+          "_type": "Epic Store Product SEO",
+          "og": {
+            "_type": "SEO OG Metadata"
+          }
+        },
+        "productSections": [
+          {
+            "productSection": "DLC",
+            "_type": "Diesel Product Section"
+          },
+          {
+            "productSection": "REQUIREMENTS",
+            "_type": "Diesel Product Section"
+          },
+          {
+            "productSection": "SOCIAL_LINKS",
+            "_type": "Diesel Product Section"
+          },
+          {
+            "productSection": "ABOUT",
+            "_type": "Diesel Product Section"
+          },
+          {
+            "productSection": "CAROUSEL",
+            "_type": "Diesel Product Section"
+          },
+          {
+            "productSection": "FOOTER",
+            "_type": "Diesel Product Section"
+          },
+          {
+            "productSection": "GALLERY",
+            "_type": "Diesel Product Section"
+          },
+          {
+            "productSection": "HERO",
+            "_type": "Diesel Product Section"
+          }
+        ],
+        "gallery": {
+          "_type": "Diesel Gallery",
+          "galleryImages": [
+            {
+              "src": "https://cdn2.unrealengine.com/Diesel%2Fproductv2%2Fhitman%2Fhome%2FEGS_IOInteractiveAS_HITMANTheCompleteFirstSeason_G1A_00-1920x1080-badcc937b70155e57bf86e075283ed1060962bb7.jpg",
+              "_type": "Diesel Gallery Image",
+              "row": 1
+            },
+            {
+              "src": "https://cdn2.unrealengine.com/Diesel%2Fproductv2%2Fhitman%2Fhome%2FEGS_IOInteractiveAS_HITMANTheCompleteFirstSeason_G1A_01-1920x1080-7a0feff0ff3bc28827a99f45b655042f7f9a810b.jpg",
+              "_type": "Diesel Gallery Image",
+              "row": 2
+            },
+            {
+              "src": "https://cdn2.unrealengine.com/Diesel%2Fproductv2%2Fhitman%2Fhome%2FEGS_IOInteractiveAS_HITMANTheCompleteFirstSeason_G1A_02-1920x1080-358b2bef1a14735c36266bda2ec57d9dab95bb71.jpg",
+              "_type": "Diesel Gallery Image",
+              "row": 2
+            },
+            {
+              "src": "https://cdn2.unrealengine.com/Diesel%2Fproductv2%2Fhitman%2Fhome%2FEGS_IOInteractiveAS_HITMANTheCompleteFirstSeason_G1A_03-1920x1080-539bda3e1756c22417d7cb754b6fabd0ae4672ba.jpg",
+              "_type": "Diesel Gallery Image",
+              "row": 3
+            }
+          ]
+        },
+        "navTitle": "HITMAN"
+      },
+      "ageGate": {
+        "hasAgeGate": true,
+        "_type": "Epic Store Age Gate"
+      },
+      "tag": "edition",
+      "type": "offer"
+    },
+    {
+      "productRatings": {
+        "ratings": [
+          {
+            "image": {
+              "src": "https://cdn2.unrealengine.com/egs-hitman-iointeractiveas-ra1-370x208-370x208-829765488.png",
+              "_type": "Epic Store Image"
+            },
+            "countryCodes": "US,CA,MX",
+            "_type": "Epic Store Rating",
+            "title": "MATURE 17 +"
+          },
+          {
+            "image": {
+              "src": "https://cdn2.unrealengine.com/Diesel%2Fproduct%2Fratings%2FPEGI_18_Rating-208x254-f12521f5a5231d533ff539144709543cdf68f031.jpg",
+              "_type": "Epic Store Image"
+            },
+            "countryCodes": "AT,BE,BG,HR,CY,CZ,DK,EE,FI,FR,GR,HU,IE,IT,LV,LT,LU,MT,NL,PL,PT,RO,SK,SI,ES,SE,GB",
+            "_type": "Epic Store Rating",
+            "title": "PEGI 18"
+          },
+          {
+            "image": {
+              "src": "https://cdn2.unrealengine.com/Diesel%2Fproduct%2Fratings%2FUSK_18-400x400-7ac38d8b4b29de7c5f10a52ebf17f124e361279e.png",
+              "_type": "Epic Store Image"
+            },
+            "countryCodes": "DE",
+            "_type": "Epic Store Rating",
+            "title": "USK ab 18"
+          },
+          {
+            "image": {
+              "src": "https://cdn2.unrealengine.com/18-v-l-d-c-540x117-672303047.png",
+              "_type": "Epic Store Image"
+            },
+            "countryCodes": "KR",
+            "_type": "Epic Store Rating",
+            "title": "청소년이용불가"
+          },
+          {
+            "image": {
+              "src": "https://cdn2.unrealengine.com/Diesel%2Fproduct%2Fratings%2F800px-CERO_Z.svg-800x984-ffd454acb3d6f8fac8bdf1bf2a2d01da0d79f858.png",
+              "_type": "Epic Store Image"
+            },
+            "countryCodes": "JP",
+            "_type": "Epic Store Rating",
+            "title": "CERO Z"
+          }
+        ],
+        "_type": "Epic Store Product Ratings"
+      },
+      "disableNewAddons": true,
+      "modMarketplaceEnabled": false,
+      "_title": "home",
+      "regionBlock": "",
+      "_noIndex": false,
+      "_images_": [
+        "https://cdn2.unrealengine.com/Diesel%2Fproductv2%2Fhitman%2Fgame-of-the-year-edition%2FEGS_IOInteractiveAS_HITMANGameofTheYeardEdition_G1A_01-1920x1080-f73e7dc1b12fdc311fa56ca569b891f5a6fb721c.jpg",
+        "https://cdn2.unrealengine.com/Diesel%2Fproductv2%2Fhitman%2Fgame-of-the-year-edition%2FEGS_IOInteractiveAS_HITMANGameofTheYeardEdition_G1A_05-1920x1080-539bda3e1756c22417d7cb754b6fabd0ae4672ba.jpg",
+        "https://cdn2.unrealengine.com/egs-hitmangameoftheyeardedition-iointeractiveas-bundles-g1a-07-1920x1080-623151153.jpg",
+        "https://cdn2.unrealengine.com/Diesel%2Fproductv2%2Fhitman%2Fgame-of-the-year-edition%2FEGS_IOInteractiveAS_HITMANGameofTheYeardEdition_G1A_03-1920x1080-52c8d8cd02e0c51a26c00af79b926a3d66865676.jpg",
+        "https://cdn2.unrealengine.com/egs-hitman-iointeractiveas-s5-1920x1080-551403315.jpg",
+        "https://cdn2.unrealengine.com/Diesel%2Fproductv2%2Fhitman%2Fgame-of-the-year-edition%2FEGS_IOInteractiveAS_HITMANGameofTheYeardEdition_IC1-200x200-015b336a367d6c1059a94cfd77c0e947ef217439.png",
+        "https://cdn2.unrealengine.com/egs-hitmangameoftheyearupgrade-iointeractiveas-dlc-s1-2560x1440-623108052.jpg",
+        "https://cdn2.unrealengine.com/Diesel%2Fproductv2%2Fhitman%2Fgame-of-the-year-edition%2FEGS_IOInteractiveAS_HITMANGameofTheYeardEdition_G1A_02-1920x1080-badcc937b70155e57bf86e075283ed1060962bb7.jpg",
+        "https://cdn2.unrealengine.com/egs-hitmangameoftheyeardedition-iointeractiveas-bundles-s2-1200x1600-718536009.jpg",
+        "https://cdn2.unrealengine.com/Diesel%2Fproductv2%2Fhitman%2Fhome%2FEGS_IOInteractiveAS_HITMANTheCompleteFirstSeason_IC4-200x200-1ab71aa040d81bd4259caec68389a82c5be1e6c6.png",
+        "https://cdn2.unrealengine.com/Diesel%2Fproductv2%2Fhitman%2Fgame-of-the-year-edition%2FEGS_IOInteractiveAS_HITMANGameofTheYeardEdition_G1A_00-1920x1080-62460b6fbe740e14604f30c6e7efcc1e5493482c.jpg",
+        "https://cdn2.unrealengine.com/Diesel%2Fproductv2%2Fhitman%2Fgame-of-the-year-edition%2FEGS_IOInteractiveAS_HITMANGameofTheYeardEdition_G1A_04-1920x1080-358b2bef1a14735c36266bda2ec57d9dab95bb71.jpg",
+        "https://cdn2.unrealengine.com/egs-hitmangameoftheyeardedition-iointeractiveas-bundles-s1-2560x1440-718536276.jpg"
+      ],
+      "productName": "Hitman 2016",
+      "jcr:isCheckedOut": true,
+      "namespace": "3c06b15a8a2845c0b725d4f952fe00aa",
+      "theme": {
+        "buttonPrimaryBg": "#FFDF00",
+        "customPrimaryBg": "",
+        "accentColor": "#FFDF00",
+        "_type": "Diesel Theme",
+        "colorScheme": "dark"
+      },
+      "reviewOptOut": false,
+      "jcr:baseVersion": "a7ca237317f1e7021bb5b6-954c-4ddf-938b-429638093aae",
+      "externalNavLinks": {
+        "_type": "Epic Store Links"
+      },
+      "_urlPattern": "/productv2/hitman/home",
+      "_slug": "home",
+      "_activeDate": "2020-02-04T14:45:10.836Z",
+      "lastModified": "2020-08-24T15:12:01.434Z",
+      "_locale": "en-US",
+      "_id": "ad158d2a-71de-4be1-afe6-1ae16160bbd6",
+      "offer": {
+        "regionRestrictions": {
+          "_type": "Store Region Filtering"
+        },
+        "_type": "Diesel Offer",
+        "namespace": "3c06b15a8a2845c0b725d4f952fe00aa",
+        "id": "f536990dc8164c829b410861caf17add",
+        "type": "edition",
+        "hasOffer": true
+      },
+      "item": {
+        "catalogId": "",
+        "appName": "",
+        "_type": "Diesel Product Item",
+        "namespace": "",
+        "hasItem": false
+      },
+      "data": {
+        "productLinks": {
+          "_type": "Diesel Product Lins"
+        },
+        "socialLinks": {
+          "linkNaver": "",
+          "linkTwitter": "https://twitter.com/hitman",
+          "linkFacebook": "https://www.facebook.com/hitman",
+          "_type": "Diesel Social Links",
+          "linkVk": "",
+          "linkDiscord": "",
+          "linkReddit": "https://www.reddit.com/r/HiTMAN/",
+          "title": "Follow HITMAN",
+          "linkTwitch": "http://www.twitch.tv/hitman",
+          "linkYoutube": "https://www.youtube.com/user/hitman?hl=en&gl=US",
+          "linkYouku": "",
+          "linkWeibo": "",
+          "linkHomepage": "https://hitman.com",
+          "linkInstagram": ""
+        },
+        "requirements": {
+          "languages": [
+            "AUDIO - English",
+            "TEXT - English, French, German, Italian, Spanish - Spain, Japanese, Polish, Portuguese - Brazil, Russian, Chinese - Simplified"
+          ],
+          "systems": [
+            {
+              "_type": "Diesel System Detail",
+              "systemType": "Windows",
+              "details": [
+                {
+                  "_type": "Diesel System Detail Item",
+                  "title": "OS",
+                  "minimum": "OS 64-bit Windows 7",
+                  "recommended": "OS 64-bit Windows 7 / 64-bit Windows 8 (8.1) or Windows 10"
+                },
+                {
+                  "_type": "Diesel System Detail Item",
+                  "title": "Processor",
+                  "minimum": "Intel CPU Core i5-2500K 3.3GHz / AMD CPU Phenom II X4 940",
+                  "recommended": "Intel CPU Core i7 3770 3,4 GHz / AMD CPU AMD FX-8350 4 GHz"
+                },
+                {
+                  "_type": "Diesel System Detail Item",
+                  "title": "Memory",
+                  "minimum": "8",
+                  "recommended": "8"
+                },
+                {
+                  "_type": "Diesel System Detail Item",
+                  "title": "Graphics",
+                  "minimum": "NVIDIA GeForce GTX 660 / Radeon HD 7870",
+                  "recommended": "Nvidia GPU GeForce GTX 770 / AMD GPU Radeon R9 290"
+                },
+                {
+                  "_type": "Diesel System Detail Item",
+                  "title": "DirectX",
+                  "minimum": "11",
+                  "recommended": "11"
+                },
+                {
+                  "_type": "Diesel System Detail Item",
+                  "title": "Storage",
+                  "minimum": "50 ",
+                  "recommended": "50"
+                }
+              ]
+            }
+          ],
+          "_type": "Diesel System Details",
+          "rating": {
+            "_type": "Diesel Rating"
+          }
+        },
+        "navOrder": 1,
+        "footer": {
+          "_type": "Diesel Product Footer",
+          "copy": "HITMAN™ © 2020 IO Interactive A/S. Published by IO Interactive A/S. IO INTERACTIVE, the IO logo, HITMAN™, the HITMAN™ logos, and WORLD OF ASSASSINATION are trademarks or registered trademarks owned by or exclusively licensed to IO Interactive A/S. All rights reserved. All other trademarks are the property of their respective owners.",
+          "privacyPolicyLink": {
+            "src": "https://www.ioi.dk/privacy-policy/",
+            "_type": "Diesel Link",
+            "title": "IO Interactive A/S Privacy Policy"
+          }
+        },
+        "_type": "Diesel Product Detail",
+        "about": {
+          "image": {
+            "src": "https://cdn2.unrealengine.com/egs-hitmangameoftheyeardedition-iointeractiveas-bundles-s2-1200x1600-718536009.jpg",
+            "_type": "Diesel Image"
+          },
+          "developerAttribution": "IO Interactive A/S",
+          "_type": "Diesel Product About",
+          "publisherAttribution": "IO Interactive A/S",
+          "description": "Experiment and have fun in the ultimate playground as Agent 47 to become the master assassin. Travel around the globe to exotic locations and eliminate your targets with everything from a katana or a sniper rifle to an exploding golf ball or some expired spaghetti sauce.\n\nThe HITMAN - Game of The Year Edition includes:\n\n- All missions & locations from the award-winning first season of HITMAN\n- \"Patient Zero\" Bonus campaign \n- 3 new Themed Escalation Contracts\n- 3 new Outfits\n- 3 new Weapons",
+          "shortDescription": "The HITMAN - Game of The Year Edition includes: All missions & locations from the award-winning first season of HITMAN; \"Patient Zero\" Bonus campaign; 3 new Themed Escalation Contracts; 3 new Outfits; 3 new Weapons",
+          "title": "HITMAN - Game of The Year Edition",
+          "developerLogo": {
+            "src": "https://cdn2.unrealengine.com/Diesel%2Fproductv2%2Fhitman%2Fhome%2FEGS_IOInteractiveAS_HITMANTheCompleteFirstSeason_IC4-200x200-1ab71aa040d81bd4259caec68389a82c5be1e6c6.png",
+            "_type": "Diesel Image"
+          }
+        },
+        "banner": {
+          "showPromotion": false,
+          "_type": "Epic Store Product Banner",
+          "link": {
+            "_type": "Diesel Link"
+          }
+        },
+        "hero": {
+          "logoImage": {
+            "src": "https://cdn2.unrealengine.com/Diesel%2Fproductv2%2Fhitman%2Fgame-of-the-year-edition%2FEGS_IOInteractiveAS_HITMANGameofTheYeardEdition_IC1-200x200-015b336a367d6c1059a94cfd77c0e947ef217439.png",
+            "_type": "Diesel Image"
+          },
+          "portraitBackgroundImageUrl": "https://cdn2.unrealengine.com/egs-hitmangameoftheyeardedition-iointeractiveas-bundles-s2-1200x1600-718536009.jpg",
+          "_type": "Diesel Hero",
+          "action": {
+            "_type": "Diesel Action"
+          },
+          "video": {
+            "loop": false,
+            "_type": "Diesel Video",
+            "hasFullScreen": false,
+            "hasControls": false,
+            "muted": false,
+            "autoplay": false
+          },
+          "title": "HITMAN - Game of The Yeard Edition",
+          "isFullBleed": false,
+          "altContentPosition": false,
+          "backgroundImageUrl": "https://cdn2.unrealengine.com/egs-hitmangameoftheyeardedition-iointeractiveas-bundles-s1-2560x1440-718536276.jpg"
+        },
+        "carousel": {
+          "_type": "Diesel Carousel",
+          "items": [
+            {
+              "image": {
+                "_type": "Diesel Image"
+              },
+              "_type": "Diesel Carousel Item - Image OR Video",
+              "video": {
+                "epicStillDurationSeconds": 2,
+                "recipes": "{\n    \"en-US\": [\n        {\n            \"recipe\": \"video-fmp4\",\n            \"mediaRefId\": \"93334210324545ea8c74d4c40e3d913d\"\n        },\n        {\n            \"recipe\": \"video-webm\",\n            \"mediaRefId\": \"7366cb6cc7784c709f0abafaf6677c05\"\n        },\n        {\n            \"recipe\": \"video-hls\",\n            \"mediaRefId\": \"145d7ac5a75d45a08ae1504bf6d74660\"\n        }\n    ]\n}",
+                "epicStillType": "PREPEND",
+                "loop": true,
+                "_type": "Diesel Video",
+                "hasFullScreen": true,
+                "hasControls": true,
+                "title": "HITMAN GOTY Trailer",
+                "type": "epicHosted",
+                "muted": false,
+                "autoplay": true
+              }
+            }
+          ]
+        },
+        "editions": {
+          "editions": [
+            {
+              "regionRestrictions": {
+                "_type": "Store Region Filtering"
+              },
+              "image": {
+                "src": "https://cdn2.unrealengine.com/egs-hitmangameoftheyeardedition-iointeractiveas-bundles-s1-2560x1440-718536276.jpg",
+                "_type": "Diesel Image"
+              },
+              "_type": "Product Edition",
+              "namespace": "3c06b15a8a2845c0b725d4f952fe00aa",
+              "description": "The HITMAN - Game of The Year Edition includes: All missions & locations from the award-winning first season of HITMAN; \"Patient Zero\" Bonus campaign; 3 new Themed Escalation Contracts; 3 new Outfits; 3 new Weapons",
+              "offerId": "f536990dc8164c829b410861caf17add",
+              "tag": "edition",
+              "title": "HITMAN - Game of the Year Edition",
+              "slug": "product/hitman/home"
+            },
+            {
+              "regionRestrictions": {
+                "_type": "Store Region Filtering"
+              },
+              "image": {
+                "src": "https://cdn2.unrealengine.com/egs-hitman-iointeractiveas-s5-1920x1080-551403315.jpg",
+                "_type": "Diesel Image"
+              },
+              "_type": "Product Edition",
+              "namespace": "3c06b15a8a2845c0b725d4f952fe00aa",
+              "description": "Experiment and have fun in the ultimate playground as Agent 47 to become the master assassin. Travel around the globe to exotic locations and eliminate your targets with everything from a katana or a sniper rifle to an exploding golf ball.",
+              "offerId": "e8efad3d47a14284867fef2c347c321d",
+              "tag": "edition",
+              "title": "HITMAN",
+              "slug": "product/hitman/standard-edition"
+            }
+          ],
+          "_type": "Epic Store Editions",
+          "enableImages": true
+        },
+        "meta": {
+          "releaseDate": "2020-08-27T15:00:00.000Z",
+          "_type": "Epic Store Meta",
+          "publisher": [
+            "IO Interactive A/S"
+          ],
+          "logo": {
+            "_type": "Epic Store Image"
+          },
+          "developer": [
+            "IO Interactive A/S"
+          ],
+          "customReleaseDate": "Coming Soon",
+          "platform": [
+            "Windows"
+          ],
+          "tags": [
+            "ACTION",
+            "STEALTH"
+          ]
+        },
+        "markdown": {
+          "_type": "Epic Store Markdown"
+        },
+        "dlc": {
+          "contingentOffer": {
+            "regionRestrictions": {
+              "_type": "Store Region Filtering"
+            },
+            "_type": "Diesel Offer",
+            "hasOffer": false
+          },
+          "_type": "Epic Store DLC",
+          "dlc": [
+            {
+              "regionRestrictions": {
+                "_type": "Store Region Filtering"
+              },
+              "image": {
+                "src": "https://cdn2.unrealengine.com/egs-hitmangameoftheyearupgrade-iointeractiveas-dlc-s1-2560x1440-623108052.jpg",
+                "_type": "Diesel Image"
+              },
+              "_type": "Product DLC",
+              "namespace": "3c06b15a8a2845c0b725d4f952fe00aa",
+              "description": "Upgrade your copy of HITMAN to the GOTY Edition now and get immediate access to the Patient Zero campaign plus all the other new content included in the GOTY Edition",
+              "offerId": "e573ab5b700a418bade0407694c125d6",
+              "tag": "dlc",
+              "title": "HITMAN - Game of the Year Upgrade",
+              "type": "addon",
+              "slug": "product/hitman/game-of-the-year-upgrade"
+            }
+          ],
+          "enableImages": true
+        },
+        "seo": {
+          "image": {
+            "_type": "Epic Store Image"
+          },
+          "twitter": {
+            "_type": "SEO Twitter Metadata"
+          },
+          "_type": "Epic Store Product SEO",
+          "og": {
+            "_type": "SEO OG Metadata"
+          }
+        },
+        "productSections": [
+          {
+            "productSection": "DLC",
+            "_type": "Diesel Product Section"
+          },
+          {
+            "productSection": "EDITIONS",
+            "_type": "Diesel Product Section"
+          },
+          {
+            "productSection": "REQUIREMENTS",
+            "_type": "Diesel Product Section"
+          },
+          {
+            "productSection": "SOCIAL_LINKS",
+            "_type": "Diesel Product Section"
+          },
+          {
+            "productSection": "ABOUT",
+            "_type": "Diesel Product Section"
+          },
+          {
+            "productSection": "CAROUSEL",
+            "_type": "Diesel Product Section"
+          },
+          {
+            "productSection": "FOOTER",
+            "_type": "Diesel Product Section"
+          },
+          {
+            "productSection": "GALLERY",
+            "_type": "Diesel Product Section"
+          },
+          {
+            "productSection": "HERO",
+            "_type": "Diesel Product Section"
+          }
+        ],
+        "gallery": {
+          "_type": "Diesel Gallery",
+          "galleryImages": [
+            {
+              "src": "https://cdn2.unrealengine.com/Diesel%2Fproductv2%2Fhitman%2Fgame-of-the-year-edition%2FEGS_IOInteractiveAS_HITMANGameofTheYeardEdition_G1A_00-1920x1080-62460b6fbe740e14604f30c6e7efcc1e5493482c.jpg",
+              "_type": "Diesel Gallery Image",
+              "row": 1
+            },
+            {
+              "src": "https://cdn2.unrealengine.com/Diesel%2Fproductv2%2Fhitman%2Fgame-of-the-year-edition%2FEGS_IOInteractiveAS_HITMANGameofTheYeardEdition_G1A_01-1920x1080-f73e7dc1b12fdc311fa56ca569b891f5a6fb721c.jpg",
+              "_type": "Diesel Gallery Image",
+              "row": 2
+            },
+            {
+              "src": "https://cdn2.unrealengine.com/Diesel%2Fproductv2%2Fhitman%2Fgame-of-the-year-edition%2FEGS_IOInteractiveAS_HITMANGameofTheYeardEdition_G1A_02-1920x1080-badcc937b70155e57bf86e075283ed1060962bb7.jpg",
+              "_type": "Diesel Gallery Image",
+              "row": 2
+            },
+            {
+              "src": "https://cdn2.unrealengine.com/Diesel%2Fproductv2%2Fhitman%2Fgame-of-the-year-edition%2FEGS_IOInteractiveAS_HITMANGameofTheYeardEdition_G1A_03-1920x1080-52c8d8cd02e0c51a26c00af79b926a3d66865676.jpg",
+              "_type": "Diesel Gallery Image",
+              "row": 3
+            },
+            {
+              "src": "https://cdn2.unrealengine.com/Diesel%2Fproductv2%2Fhitman%2Fgame-of-the-year-edition%2FEGS_IOInteractiveAS_HITMANGameofTheYeardEdition_G1A_04-1920x1080-358b2bef1a14735c36266bda2ec57d9dab95bb71.jpg",
+              "_type": "Diesel Gallery Image",
+              "row": 4
+            },
+            {
+              "src": "https://cdn2.unrealengine.com/Diesel%2Fproductv2%2Fhitman%2Fgame-of-the-year-edition%2FEGS_IOInteractiveAS_HITMANGameofTheYeardEdition_G1A_05-1920x1080-539bda3e1756c22417d7cb754b6fabd0ae4672ba.jpg",
+              "_type": "Diesel Gallery Image",
+              "row": 4
+            },
+            {
+              "src": "https://cdn2.unrealengine.com/egs-hitmangameoftheyeardedition-iointeractiveas-bundles-g1a-07-1920x1080-623151153.jpg",
+              "_type": "Diesel Gallery Image",
+              "row": 5
+            }
+          ]
+        },
+        "navTitle": "HITMAN - Game of the Year Edition"
+      },
+      "ageGate": {
+        "hasAgeGate": true,
+        "_type": "Epic Store Age Gate"
+      },
+      "tag": "edition",
+      "type": "productHome"
+    },
+    {
+      "productRatings": {
+        "ratings": [
+          {
+            "image": {
+              "src": "https://cdn2.unrealengine.com/egs-hitman-iointeractiveas-ra1-370x208-370x208-829765488.png",
+              "_type": "Epic Store Image"
+            },
+            "countryCodes": "US,CA,MX",
+            "_type": "Epic Store Rating",
+            "title": "MATURE 17 +"
+          },
+          {
+            "image": {
+              "src": "https://cdn2.unrealengine.com/Diesel%2Fproduct%2Fratings%2FPEGI_18_Rating-208x254-f12521f5a5231d533ff539144709543cdf68f031.jpg",
+              "_type": "Epic Store Image"
+            },
+            "countryCodes": "AT,BE,BG,HR,CY,CZ,DK,EE,FI,FR,GR,HU,IE,IT,LV,LT,LU,MT,NL,PL,PT,RO,SK,SI,ES,SE,GB",
+            "_type": "Epic Store Rating",
+            "title": "PEGI 18"
+          },
+          {
+            "image": {
+              "src": "https://cdn2.unrealengine.com/Diesel%2Fproduct%2Fratings%2FUSK_18-400x400-7ac38d8b4b29de7c5f10a52ebf17f124e361279e.png",
+              "_type": "Epic Store Image"
+            },
+            "countryCodes": "DE",
+            "_type": "Epic Store Rating",
+            "title": "USK ab 18"
+          },
+          {
+            "image": {
+              "src": "https://cdn2.unrealengine.com/18-v-l-d-c-540x117-672303047.png",
+              "_type": "Epic Store Image"
+            },
+            "countryCodes": "KR",
+            "_type": "Epic Store Rating",
+            "title": "청소년이용불가"
+          },
+          {
+            "image": {
+              "src": "https://cdn2.unrealengine.com/Diesel%2Fproduct%2Fratings%2F800px-CERO_Z.svg-800x984-ffd454acb3d6f8fac8bdf1bf2a2d01da0d79f858.png",
+              "_type": "Epic Store Image"
+            },
+            "countryCodes": "JP",
+            "_type": "Epic Store Rating",
+            "title": "CERO Z"
+          }
+        ],
+        "_type": "Epic Store Product Ratings"
+      },
+      "disableNewAddons": true,
+      "modMarketplaceEnabled": false,
+      "_title": "game-of-the-year-upgrade",
+      "regionBlock": "",
+      "_noIndex": false,
+      "_images_": [
+        "https://cdn2.unrealengine.com/egs-hitman-iointeractiveas-ic3-200x200-551403813.png",
+        "https://cdn2.unrealengine.com/Diesel%2Fproductv2%2Fhitman%2Fgame-of-the-year-upgrade%2FEGS_IOInteractiveAS_HITMANGameofTheYearUpgrade_G1A_00-1920x1080-62460b6fbe740e14604f30c6e7efcc1e5493482c.jpg",
+        "https://cdn2.unrealengine.com/egs-hitmangameoftheyearupgrade-iointeractiveas-dlc-s1-2560x1440-623108052.jpg",
+        "https://cdn2.unrealengine.com/egs-hitmangameoftheyearupgrade-iointeractiveas-dlc-s2-1200x1600-623107765.jpg",
+        "https://cdn2.unrealengine.com/Diesel%2Fproductv2%2Fhitman%2Fgame-of-the-year-upgrade%2FEGS_IOInteractiveAS_HITMANGameofTheYearUpgrade_G1A_01-1920x1080-f73e7dc1b12fdc311fa56ca569b891f5a6fb721c.jpg",
+        "https://cdn2.unrealengine.com/egs-hitmangameoftheyearupgrade-iointeractiveas-dlc-g1a-03-1920x1080-623104941.jpg",
+        "https://cdn2.unrealengine.com/Diesel%2Fproductv2%2Fhitman%2Fgame-of-the-year-upgrade%2FEGS_IOInteractiveAS_HITMANGameofTheYearUpgrade_G2_00-1462x932-15144c2d011f8268027f21cac7558c34ff5d7034.jpg",
+        "https://cdn2.unrealengine.com/Diesel%2Fproductv2%2Fhitman%2Fgame-of-the-year-upgrade%2FEGS_IOInteractiveAS_HITMANGameofTheYearUpgrade_IC1-200x200-1edab34af5099dd98909cfb711aadfc72522c46d.png"
+      ],
+      "productName": "Hitman 2016",
+      "jcr:isCheckedOut": true,
+      "namespace": "3c06b15a8a2845c0b725d4f952fe00aa",
+      "theme": {
+        "buttonPrimaryBg": "#FFDF00",
+        "customPrimaryBg": "#000000",
+        "accentColor": "#FFDF00",
+        "_type": "Diesel Theme",
+        "colorScheme": "dark"
+      },
+      "reviewOptOut": false,
+      "jcr:baseVersion": "a7ca237317f1e7996085f3-eb98-4417-8600-24401aee097e",
+      "externalNavLinks": {
+        "_type": "Epic Store Links"
+      },
+      "_urlPattern": "/productv2/hitman/game-of-the-year-upgrade",
+      "_slug": "game-of-the-year-upgrade",
+      "_activeDate": "2020-02-04T14:45:10.836Z",
+      "lastModified": "2020-08-27T15:22:25.169Z",
+      "_locale": "en-US",
+      "_id": "88fd9512-f03b-4d62-91b1-deb156bdf420",
+      "offer": {
+        "regionRestrictions": {
+          "_type": "Store Region Filtering"
+        },
+        "_type": "Diesel Offer",
+        "namespace": "3c06b15a8a2845c0b725d4f952fe00aa",
+        "id": "e573ab5b700a418bade0407694c125d6",
+        "tag": "dlc",
+        "type": "addOn",
+        "hasOffer": true
+      },
+      "item": {
+        "catalogId": "92cd8e3c23a6400986db14bef51caa51",
+        "appName": "Barbet",
+        "_type": "Diesel Product Item",
+        "namespace": "3c06b15a8a2845c0b725d4f952fe00aa",
+        "hasItem": true
+      },
+      "data": {
+        "productLinks": {
+          "_type": "Diesel Product Lins"
+        },
+        "socialLinks": {
+          "linkNaver": "",
+          "linkTwitter": "https://twitter.com/hitman",
+          "linkFacebook": "https://www.facebook.com/hitman",
+          "_type": "Diesel Social Links",
+          "linkVk": "",
+          "linkDiscord": "",
+          "linkReddit": "https://www.reddit.com/r/HiTMAN/",
+          "title": "Follow HITMAN",
+          "linkTwitch": "http://www.twitch.tv/hitman",
+          "linkYoutube": "https://www.youtube.com/user/hitman?hl=en&gl=US",
+          "linkYouku": "",
+          "linkWeibo": "",
+          "linkHomepage": "https://hitman.com",
+          "linkInstagram": ""
+        },
+        "requirements": {
+          "languages": [
+            "AUDIO - English",
+            "TEXT - English, French, German, Italian, Spanish - Spain, Japanese, Polish, Portuguese - Brazil, Russian, Chinese - Simplified"
+          ],
+          "systems": [
+            {
+              "_type": "Diesel System Detail",
+              "systemType": "Windows",
+              "details": [
+                {
+                  "_type": "Diesel System Detail Item",
+                  "title": "OS",
+                  "minimum": "OS 64-bit Windows 7",
+                  "recommended": "OS 64-bit Windows 7 / 64-bit Windows 8 (8.1) or Windows 10"
+                },
+                {
+                  "_type": "Diesel System Detail Item",
+                  "title": "Processor",
+                  "minimum": "Intel CPU Core i5-2500K 3.3GHz / AMD CPU Phenom II X4 940",
+                  "recommended": "Intel CPU Core i7 3770 3,4 GHz / AMD CPU AMD FX-8350 4 GHz"
+                },
+                {
+                  "_type": "Diesel System Detail Item",
+                  "title": "Memory",
+                  "minimum": "8",
+                  "recommended": "8"
+                },
+                {
+                  "_type": "Diesel System Detail Item",
+                  "title": "Graphics",
+                  "minimum": "NVIDIA GeForce GTX 660 / Radeon HD 7870",
+                  "recommended": "Nvidia GPU GeForce GTX 770 / AMD GPU Radeon R9 290"
+                },
+                {
+                  "_type": "Diesel System Detail Item",
+                  "title": "DirectX",
+                  "minimum": "11",
+                  "recommended": "11"
+                },
+                {
+                  "_type": "Diesel System Detail Item",
+                  "title": "Storage",
+                  "minimum": "50 ",
+                  "recommended": "50"
+                }
+              ]
+            }
+          ],
+          "_type": "Diesel System Details",
+          "rating": {
+            "_type": "Diesel Rating"
+          }
+        },
+        "navOrder": 3,
+        "footer": {
+          "_type": "Diesel Product Footer",
+          "copy": "HITMAN™ © 2020 IO Interactive A/S. Published by IO Interactive A/S. IO INTERACTIVE, the IO logo, HITMAN™, the HITMAN™ logos, and WORLD OF ASSASSINATION are trademarks or registered trademarks owned by or exclusively licensed to IO Interactive A/S. All rights reserved. All other trademarks are the property of their respective owners.",
+          "privacyPolicyLink": {
+            "src": "https://www.ioi.dk/privacy-policy/",
+            "_type": "Diesel Link",
+            "title": "IO Interactive A/S Privacy Policy"
+          }
+        },
+        "_type": "Diesel Product Detail",
+        "about": {
+          "image": {
+            "src": "https://cdn2.unrealengine.com/Diesel%2Fproductv2%2Fhitman%2Fgame-of-the-year-upgrade%2FEGS_IOInteractiveAS_HITMANGameofTheYearUpgrade_G2_00-1462x932-15144c2d011f8268027f21cac7558c34ff5d7034.jpg",
+            "_type": "Diesel Image"
+          },
+          "developerAttribution": "IO Interactive A/S",
+          "_type": "Diesel Product About",
+          "publisherAttribution": "IO Interactive A/S",
+          "description": "Upgrade your copy of HITMAN to the GOTY Edition now and get immediate access to the Patient Zero campaign plus all the other new content included in the GOTY Edition.\n\n# The HITMAN - Game of The Year Edition Upgrade includes:\n- \"Patient Zero\" campaign featuring 4 brand new missions including new gameplay mechanics and features\n- 3 new Themed Escalation Contracts\n- 3 new Outfits\n- 3 new Weapons\n\n![Hitman image](https://cdn2.unrealengine.com/egs-hitmangameoftheyearupgrade-iointeractiveas-dlc-g2-00-1462x932-623107394.jpg)",
+          "shortDescription": "Upgrade your copy of HITMAN to the GOTY Edition now and get immediate access to the Patient Zero campaign plus all the other new content included in the GOTY Edition",
+          "title": "HITMAN - Game of the Year Upgrade",
+          "developerLogo": {
+            "src": "https://cdn2.unrealengine.com/egs-hitman-iointeractiveas-ic3-200x200-551403813.png",
+            "_type": "Diesel Image"
+          }
+        },
+        "banner": {
+          "showPromotion": false,
+          "_type": "Epic Store Product Banner",
+          "link": {
+            "_type": "Diesel Link"
+          }
+        },
+        "hero": {
+          "logoImage": {
+            "src": "https://cdn2.unrealengine.com/Diesel%2Fproductv2%2Fhitman%2Fgame-of-the-year-upgrade%2FEGS_IOInteractiveAS_HITMANGameofTheYearUpgrade_IC1-200x200-1edab34af5099dd98909cfb711aadfc72522c46d.png",
+            "_type": "Diesel Image"
+          },
+          "portraitBackgroundImageUrl": "https://cdn2.unrealengine.com/egs-hitmangameoftheyearupgrade-iointeractiveas-dlc-s2-1200x1600-623107765.jpg",
+          "_type": "Diesel Hero",
+          "action": {
+            "_type": "Diesel Action"
+          },
+          "video": {
+            "loop": false,
+            "_type": "Diesel Video",
+            "hasFullScreen": false,
+            "hasControls": false,
+            "muted": false,
+            "autoplay": false
+          },
+          "isFullBleed": false,
+          "altContentPosition": false,
+          "backgroundImageUrl": "https://cdn2.unrealengine.com/egs-hitmangameoftheyearupgrade-iointeractiveas-dlc-s1-2560x1440-623108052.jpg"
+        },
+        "carousel": {
+          "_type": "Diesel Carousel",
+          "items": [
+            {
+              "image": {
+                "_type": "Diesel Image"
+              },
+              "_type": "Diesel Carousel Item - Image OR Video",
+              "video": {
+                "epicStillDurationSeconds": 2,
+                "recipes": "{\n    \"en-US\": [\n        {\n            \"recipe\": \"video-fmp4\",\n            \"mediaRefId\": \"93334210324545ea8c74d4c40e3d913d\"\n        },\n        {\n            \"recipe\": \"video-webm\",\n            \"mediaRefId\": \"7366cb6cc7784c709f0abafaf6677c05\"\n        },\n        {\n            \"recipe\": \"video-hls\",\n            \"mediaRefId\": \"145d7ac5a75d45a08ae1504bf6d74660\"\n        }\n    ]\n}",
+                "epicStillType": "PREPEND",
+                "loop": true,
+                "_type": "Diesel Video",
+                "hasFullScreen": true,
+                "hasControls": true,
+                "title": "HITMAN GOTY Trailer",
+                "type": "epicHosted",
+                "muted": false,
+                "autoplay": true
+              }
+            }
+          ]
+        },
+        "editions": {
+          "_type": "Epic Store Editions",
+          "enableImages": false
+        },
+        "meta": {
+          "releaseDate": "2020-03-13T15:00:00.000Z",
+          "_type": "Epic Store Meta",
+          "publisher": [
+            "IO Interactive A/S"
+          ],
+          "logo": {
+            "_type": "Epic Store Image"
+          },
+          "developer": [
+            "IO Interactive A/S"
+          ],
+          "platform": [
+            "Windows"
+          ],
+          "tags": [
+            "ACTION",
+            "STEALTH"
+          ]
+        },
+        "markdown": {
+          "_type": "Epic Store Markdown"
+        },
+        "dlc": {
+          "contingentOffer": {
+            "regionRestrictions": {
+              "_type": "Store Region Filtering"
+            },
+            "_type": "Diesel Offer",
+            "hasOffer": false
+          },
+          "_type": "Epic Store DLC",
+          "enableImages": false
+        },
+        "seo": {
+          "image": {
+            "_type": "Epic Store Image"
+          },
+          "twitter": {
+            "_type": "SEO Twitter Metadata"
+          },
+          "_type": "Epic Store Product SEO",
+          "og": {
+            "_type": "SEO OG Metadata"
+          }
+        },
+        "productSections": [
+          {
+            "productSection": "REQUIREMENTS",
+            "_type": "Diesel Product Section"
+          },
+          {
+            "productSection": "SOCIAL_LINKS",
+            "_type": "Diesel Product Section"
+          },
+          {
+            "productSection": "ABOUT",
+            "_type": "Diesel Product Section"
+          },
+          {
+            "productSection": "CAROUSEL",
+            "_type": "Diesel Product Section"
+          },
+          {
+            "productSection": "FOOTER",
+            "_type": "Diesel Product Section"
+          },
+          {
+            "productSection": "GALLERY",
+            "_type": "Diesel Product Section"
+          },
+          {
+            "productSection": "HERO",
+            "_type": "Diesel Product Section"
+          }
+        ],
+        "gallery": {
+          "_type": "Diesel Gallery",
+          "galleryImages": [
+            {
+              "src": "https://cdn2.unrealengine.com/Diesel%2Fproductv2%2Fhitman%2Fgame-of-the-year-upgrade%2FEGS_IOInteractiveAS_HITMANGameofTheYearUpgrade_G1A_00-1920x1080-62460b6fbe740e14604f30c6e7efcc1e5493482c.jpg",
+              "_type": "Diesel Gallery Image",
+              "row": 1
+            },
+            {
+              "src": "https://cdn2.unrealengine.com/Diesel%2Fproductv2%2Fhitman%2Fgame-of-the-year-upgrade%2FEGS_IOInteractiveAS_HITMANGameofTheYearUpgrade_G1A_01-1920x1080-f73e7dc1b12fdc311fa56ca569b891f5a6fb721c.jpg",
+              "_type": "Diesel Gallery Image",
+              "row": 1
+            },
+            {
+              "src": "https://cdn2.unrealengine.com/egs-hitmangameoftheyearupgrade-iointeractiveas-dlc-g1a-03-1920x1080-623104941.jpg",
+              "_type": "Diesel Gallery Image",
+              "row": 2
+            }
+          ]
+        },
+        "navTitle": "HITMAN - Game of the Year Upgrade"
+      },
+      "ageGate": {
+        "hasAgeGate": true,
+        "_type": "Epic Store Age Gate"
+      },
+      "tag": "dlc",
+      "type": "addon"
+    }
+  ]
+}

--- a/test/gamePromotions.spec.mjs
+++ b/test/gamePromotions.spec.mjs
@@ -1,0 +1,67 @@
+
+import 'chai/register-expect.js';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+import gamePromotions from '../src/gamePromotions.js';
+
+function readData(name, date = null) {
+    let filename = name.replace('/', '_');
+    if (date) {
+        filename += "_" + date;
+    }
+    return JSON.parse(readFileSync(`${__dirname}/data/${filename}.json`).toString());
+}
+
+let client = {};
+client.getBundleForSlug = async function (slug) { return readData(`bundles_${slug}`, this.date) };
+client.getProductForSlug = async function (slug) { return readData(`products_${slug}`, this.date) };
+
+describe('freeGamesPromotions', () => {
+
+    let target = async (date) => {
+        client.date = date;
+        client.freeGamesPromotions = () => readData('freeGamesPromotions', date);
+
+        return (await gamePromotions.freeGamesPromotions(client))
+                          .map((o) => ({ title: o.title, id: o.id, namespace: o.namespace }));
+    }
+
+    let date = "2020-09-01";
+    context(`On ${date}`, () => {
+
+        it('should return current 100% discounted games', async function () {
+
+            let freeGames = await target(date);
+
+            expect(freeGames).to.deep.include({title: 'Shadowrun Collection',
+                                               id: 'c5cb60ecc6554c6a8d9a682b87ab04bb',
+                                               namespace: 'bd8a7e894699493fb21503837f7b66c5'});
+
+            expect(freeGames).to.deep.include({title: 'Hitman 2016',
+                                               id: 'e8efad3d47a14284867fef2c347c321d',
+                                               namespace: '3c06b15a8a2845c0b725d4f952fe00aa'});
+
+            expect(freeGames).to.have.lengthOf(2);
+        });
+
+        it('should not return coming discounted games', async function () {
+
+            let freeGames = await target(date);
+
+            expect(freeGames).to.not.deep.include({namespace: '5c0d568c71174cff8026db2606771d96'});
+        });
+
+        it('should not return other free games', async function () {
+
+            let freeGames = await target(date);
+
+            expect(freeGames).to.not.deep.include({namespace: 'd6a3cae34c5d4562832610b5b8664576'});
+        });
+
+    });
+
+});


### PR DESCRIPTION
Currently Hitman is free with 100% discount https://www.epicgames.com/store/en-US/product/hitman/standard-edition
But it was incorrectly filtered out and wasn't tried to claim it.
This PR fixes that items won't be wrongly filtered out.
