### PR TITLE
feat: improve Dockerfile, support for Debian 10

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,7 @@ node_modules
 package-lock.json
 DeviceAuthGenerator.exe
 device_auths.json
+history.json
 .egstore
 .vscode
 *.code-workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Builder stage
-FROM node:16-alpine3.13 as builder
+FROM node:16-alpine3.12 as builder
 # Install dependencies for building node modules
 # python3, g++, make: required by node-gyp
 # git: required by check-update-github
@@ -9,16 +9,19 @@ RUN apk add --no-cache --virtual \
     .gyp \
     python3=~3.8 \
     make=~4.3 \
-    g++=~10.2 \
-    git=~2.30 \
+    g++=~9.3 \
+    git=~2.26 \
     && npm install --only=production \
     && apk del .gyp
 
 # App stage
-FROM node:16-alpine3.13 as app
+FROM node:16-alpine3.12 as app
 
 WORKDIR /app
 COPY . /app
 COPY --from=builder /app/node_modules ./node_modules
+# Create empty history.json, disable loop in container
+RUN echo "{}" > history.json \
+    && sed -i 's/"loop": true/"loop": false/g' config.json
 
 CMD ["npm", "start", "--no-update-notifier"]


### PR DESCRIPTION
* Add a script to create empty history.json & disable loop
* Use Alpine 3.12 as base image to support Debian Buster

Since Debian Buster is used in many current ARM devices and it is supported until June 2024, I'm reverting back to Alpine 3.12. Will fix #113 and easier to use for ARM users.