### PR TITLE
fix: ignore device_auth.json in docker image build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,7 +5,7 @@
 node_modules
 package-lock.json
 DeviceAuthGenerator.exe
-device_auths.json
+**device_auths.json**
 history.json
 .egstore
 .vscode


### PR DESCRIPTION
Ignore device_auth.json file in any folder, because I accidentally built a docker image with this file in `/data` lol. Lesson learned.