### PR TITLE
apprise notification support

### DIFF
--- a/Dockerfile.apprise
+++ b/Dockerfile.apprise
@@ -1,0 +1,30 @@
+# Builder stage
+FROM node:16-alpine3.12 as builder
+# Install dependencies for building node modules
+# python3, g++, make: required by node-gyp
+# git: required by check-update-github
+WORKDIR /app
+COPY ./package.json ./package.json
+RUN apk add --no-cache --virtual \
+    .gyp \
+    python3=~3.8 \
+    make=~4.3 \
+    g++=~9.3 \
+    git=~2.26 \
+    && npm install --only=production \
+    && apk del .gyp
+
+# App stage
+FROM node:16-alpine3.12 as app
+
+WORKDIR /app
+# Install apprise
+#RUN apk add --no-cache python3 py3-cryptography py3-pip py3-six py3-yaml py3-click py3-markdown py3-requests py3-requests-oauthlib && pip3 --no-cache-dir install apprise
+RUN apk add --no-cache python3 py3-cryptography py3-pip && pip3 --no-cache-dir install apprise
+COPY . /app
+COPY --from=builder /app/node_modules ./node_modules
+# Create empty history.json, disable loop in container
+RUN echo "{}" > data/history.json \
+    && sed -i 's/"loop": true/"loop": false/g' data/config.json
+
+CMD ["npm", "start", "--no-update-notifier"]

--- a/claimer.js
+++ b/claimer.js
@@ -10,6 +10,7 @@ const Config = require(`${__dirname}/data/config.json`);
 const History = require(`${__dirname}/data/history.json`);
 const Logger = require("tracer").console(`${__dirname}/logger.js`);
 const Package = require("./package.json");
+const child_process = require("child_process");
 
 function isUpToDate() {
     return new Promise((res, rej) => {
@@ -38,17 +39,7 @@ function sleep(delay) {
 }
 
 (async() => {
-    let { options, delay, loop, pushbulletApiKey } = Config;
-
-    let pusher = null;
-    if (pushbulletApiKey) {
-        try {
-            const PushBullet = require("pushbullet");
-            pusher = new PushBullet(pushbulletApiKey);
-        } catch (err) {
-            Logger.error("Package 'pushbullet' is not installed, but 'pushbulletApiKey' was set in config");
-        }
-    }
+    let { options, delay, loop, appriseUrl } = Config;
 
     do {
         if (!await isUpToDate()) {
@@ -114,11 +105,23 @@ function sleep(delay) {
             }
 
             History[email] = claimedPromos;
-            if (pusher && newlyClaimedPromos.length > 0) {
+            if (appriseUrl && newlyClaimedPromos.length > 0) {
                 let notification = newlyClaimedPromos.map((promo) => promo.title).join(", ");
+               
                 try {
-                    await pusher.note({}, "New freebies claimed on Epic Games Store", notification);
-                    Logger.info("Push notification sent");
+                    let s = child_process.spawnSync("apprise", [ "-vv", "-t", "New freebies claimed on Epic Games Store", "-b", notification, appriseUrl])
+            
+                    let output = (s.stdout) ? s.stdout.toString() : "ERROR: maybe apprise not found";
+            
+                    if (output) {
+                        if (!output.includes("ERROR")) {
+                            Logger.info("Push notification sent");
+                        } else {
+                            Logger.error(`Failed to send push notification (${output})`);
+                        }
+                    } else {
+                        Logger.warn(`No output from apprise`);
+                    }
                 } catch (err) {
                     Logger.error(`Failed to send push notification (${err})`);
                 }

--- a/package.json
+++ b/package.json
@@ -59,8 +59,5 @@
         "colors": "^1.4.0",
         "epicgames-client": "Revadike/node-epicgames-client#develop",
         "tracer": "^1.0.3"
-    },
-    "optionalDependencies": {
-        "pushbullet": "^2.4.0"
     }
 }


### PR DESCRIPTION
Replace the pushbullet notifications by [apprise](https://github.com/caronc/apprise).
With this, over 50 notification services are supported, including pushbullet and discord.
You can configure it using the `appriseUrl` field in the `config.json` file with a notification url [see here](https://github.com/caronc/apprise#popular-notification-services)
As python is required, I think that it would be better to offer this optionnal feature as another tag on the docker image.
