### PR TITLE
chore: clean up dockerfile, pin package

### DIFF
--- a/Dockerfile.apprise
+++ b/Dockerfile.apprise
@@ -17,10 +17,14 @@ RUN apk add --no-cache --virtual \
 # App stage
 FROM node:16-alpine3.12 as app
 
-WORKDIR /app
 # Install apprise
-#RUN apk add --no-cache python3 py3-cryptography py3-pip py3-six py3-yaml py3-click py3-markdown py3-requests py3-requests-oauthlib && pip3 --no-cache-dir install apprise
-RUN apk add --no-cache python3 py3-cryptography py3-pip && pip3 --no-cache-dir install apprise
+RUN apk add --no-cache \
+    python3=~3.8 \
+    py3-pip=~20.1 \
+    py3-cryptography=~2.9 \
+    && pip3 --no-cache-dir install apprise==0.9.5.1
+
+WORKDIR /app
 COPY . /app
 COPY --from=builder /app/node_modules ./node_modules
 # Create empty history.json, disable loop in container


### PR DESCRIPTION
I tested apprise app in Docker image , it works well for Discord. I will write a wiki page on how to config later.

After testing, the docker image size increased by 50% lol (both compressed and extracted).

|  | Without Apprise | With Apprise |
| ------ | ------ | ------ | 
| Compressed (download size) | 42MB | 61MB |
| Pulled & extracted (on disk size) | 121MB | 191MB |

Also the build time is doubled (5m -> 10m) due to apprise long build time. So, I will create a separate tag for it in v1.5.6 and mention it in wiki.

This PR is mostly for pinning the packages, dockerlint does not like it when it is not pinned.