### PR TITLE
feat:  Disable Notification When No Freebies Found

### DIFF
--- a/claimer.js
+++ b/claimer.js
@@ -57,7 +57,7 @@ function sleep(delay) {
 }
 
 (async() => {
-    let { options, delay, loop, appriseUrl } = Config;
+    let { options, delay, loop, appriseUrl, notifyIfNoUnclaimedFreebies } = Config;
 
     do {
         Logger.info(`Epicgames Freebies Claimer (${Package.version}) by ${Package.author.name || Package.author}`);
@@ -95,7 +95,9 @@ function sleep(delay) {
 
             Logger.info(`Found ${unclaimedPromos.length} unclaimed freebie(s) for ${email}`);
             if (unclaimedPromos.length === 0) {
-                notificationMessages.push(`${email} has no unclaimed freebies`);
+                if (notifyIfNoUnclaimedFreebies) {
+                    notificationMessages.push(`${email} has no unclaimed freebies`);
+                }
                 continue;
             }
 

--- a/data/config.example.json
+++ b/data/config.example.json
@@ -2,5 +2,6 @@
     "appriseUrl": null,
     "delay": 1440,
     "loop": false,
+    "notifyIfNoUnclaimedFreebies": false,
     "options": {}
 }


### PR DESCRIPTION
I introduced a new setting to disable the notification if no freebies were claimed. This fixes #165. By default this notification is deactivated and can be activated by adding `"notifyIfNoUnclaimedFreebies": true` to the `config.json`