### PR TITLE
Remove dependency on broken colors package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
         "mocha": "*"
     },
     "dependencies": {
-        "colors": "^1.4.0",
+        "colors": "1.4.0",
         "epicgames-client": "Revadike/node-epicgames-client#develop",
         "tracer": "^1.0.3"
     }


### PR DESCRIPTION
https://snyk.io/blog/open-source-npm-packages-colors-faker/

Colors ^1.4.0 was broken and generates garbage outputs in an infinite loop. Removed dependency.